### PR TITLE
Define bernoulli_cache_num as ulong

### DIFF
--- a/bernoulli.h
+++ b/bernoulli.h
@@ -39,11 +39,11 @@
 extern "C" {
 #endif
 
-extern long TLS_PREFIX bernoulli_cache_num;
+extern ulong TLS_PREFIX bernoulli_cache_num;
 
 extern TLS_PREFIX fmpq * bernoulli_cache;
 
-void bernoulli_cache_compute(long n);
+void bernoulli_cache_compute(ulong n);
 
 /*
 Crude bound for the bits in d(n) = denom(B_n).
@@ -111,7 +111,7 @@ void bernoulli_rev_clear(bernoulli_rev_t iter);
 
 #define BERNOULLI_ENSURE_CACHED(n) \
   do { \
-    long __n = (n); \
+    ulong __n = (n); \
     if (__n >= bernoulli_cache_num) \
         bernoulli_cache_compute(__n + 1); \
   } while (0); \

--- a/bernoulli/cache_compute.c
+++ b/bernoulli/cache_compute.c
@@ -25,14 +25,14 @@
 
 #include "bernoulli.h"
 
-TLS_PREFIX long bernoulli_cache_num = 0;
+TLS_PREFIX ulong bernoulli_cache_num = 0;
 
 TLS_PREFIX fmpq * bernoulli_cache = NULL;
 
 void
 bernoulli_cleanup(void)
 {
-    long i;
+    ulong i;
 
     for (i = 0; i < bernoulli_cache_num; i++)
         fmpq_clear(bernoulli_cache + i);
@@ -43,11 +43,11 @@ bernoulli_cleanup(void)
 }
 
 void
-bernoulli_cache_compute(long n)
+bernoulli_cache_compute(ulong n)
 {
     if (bernoulli_cache_num < n)
     {
-        long i, new_num;
+        ulong i, new_num;
         bernoulli_rev_t iter;
 
         if (bernoulli_cache_num == 0)

--- a/doc/source/bernoulli.rst
+++ b/doc/source/bernoulli.rst
@@ -63,14 +63,14 @@ Generation of Bernoulli numbers
 Caching
 -------------------------------------------------------------------------------
 
-.. var:: long bernoulli_cache_num
+.. var:: ulong bernoulli_cache_num
 
 .. var:: fmpq * bernoulli_cache
 
     Cache of Bernoulli numbers. Uses thread-local storage if enabled
     in FLINT.
 
-.. function:: void bernoulli_cache_compute(long n)
+.. function:: void bernoulli_cache_compute(ulong n)
 
     Makes sure that the Bernoulli numbers up to at least `B_{n-1}` are cached.
     Calling :func:`flint_cleanup()` frees the cache.


### PR DESCRIPTION
This fixes the following warning in the header file:

```
/home/certik/repos/hashstack/default/include/bernoulli.h: In function ‘void
_bernoulli_fmpq_ui(fmpz*, fmpz*, mp_limb_t)’:
/home/certik/repos/hashstack/default/include/bernoulli.h:131:11: warning:
comparison between signed and unsigned integer expressions [-Wsign-compare]
     if (n < bernoulli_cache_num)
                ^
```

Arb compiles with this change and seems to work, i.e. I checked that the warning disappears when Arb is used in CSymPy.
