### PR TITLE
Add _arb_vec_pow_ui

### DIFF
--- a/arb.h
+++ b/arb.h
@@ -902,6 +902,14 @@ _arb_vec_set_powers(arb_ptr xs, const arb_t x, long len, long prec)
 }
 
 ARB_INLINE void
+_arb_vec_pow_ui(arb_ptr res, arb_srcptr vec, ulong p, long len, long prec)
+{
+    long i;
+    for(i = 0; i < len; i++)
+        arb_pow_ui(res + i, vec + i, p, prec);
+}
+
+ARB_INLINE void
 _arb_vec_add_error_arf_vec(arb_ptr res, arf_srcptr err, long len)
 {
     long i;


### PR DESCRIPTION
This is a useful function.  If you agree, @fredrik-johansson, I'll add arb_vec_pow_si and the acb_vec_pow_ui/si as well.  Also, should I add documentation for vec functions? 