### PR TITLE
MAINT: use n_gcd_full for FLINT 2.4 compatibility

### DIFF
--- a/acb_modular/hilbert_class_poly.c
+++ b/acb_modular/hilbert_class_poly.c
@@ -126,7 +126,7 @@ acb_modular_hilbert_class_poly(fmpz_poly_t res, slong D)
 
         do
         {
-            if (ac % a == 0 && n_gcd(n_gcd(a, b), ac/a) == 1)
+            if (ac % a == 0 && n_gcd_full(n_gcd(a, b), ac/a) == 1)
             {
                 c = ac / a;
 


### PR DESCRIPTION
closes https://github.com/fredrik-johansson/arb/issues/59