### PR TITLE
TST: acb mat mul test enhancement

### DIFF
--- a/acb_mat/test/t-mul.c
+++ b/acb_mat/test/t-mul.c
@@ -26,6 +26,59 @@
 #include "acb_mat.h"
 
 
+ACB_INLINE int
+_acb_contains_fmpq_fmpq(const acb_t x, const fmpq_t a, const fmpq_t b)
+{
+    return arb_contains_fmpq(acb_realref(x), a) &&
+            arb_contains_fmpq(acb_imagref(x), b);
+}
+
+ACB_INLINE void
+_acb_set_fmpq_fmpq(acb_t z, const fmpq_t x, const fmpq_t y, slong prec)
+{
+    arb_set_fmpq(acb_realref(z), x, prec);
+    arb_set_fmpq(acb_imagref(z), y, prec);
+}
+
+int
+_acb_mat_contains_fmpq_mat_fmpq_mat(const acb_mat_t mat1,
+    const fmpq_mat_t mat2, const fmpq_mat_t mat3)
+{
+    slong i, j, n, m;
+
+    n = acb_mat_nrows(mat1);
+    m = acb_mat_ncols(mat1);
+
+    if ((n != acb_mat_nrows(mat2)) || (m != acb_mat_ncols(mat2)) ||
+        (n != acb_mat_nrows(mat3)) || (m != acb_mat_ncols(mat3)))
+        return 0;
+
+    for (i = 0; i < n; i++)
+        for (j = 0; j < m; j++)
+            if (!_acb_contains_fmpq_fmpq(acb_mat_entry(mat1, i, j),
+                fmpq_mat_entry(mat2, i, j), fmpq_mat_entry(mat3, i, j)))
+                return 0;
+
+    return 1;
+}
+
+void
+_acb_mat_set_fmpq_mat_fmpq_mat(acb_mat_t dest,
+    const fmpq_mat_t realsrc, const fmpq_mat_t imagsrc, slong prec)
+{
+    slong i, j;
+
+    if (acb_mat_ncols(dest) != 0)
+    {
+        for (i = 0; i < acb_mat_nrows(dest); i++)
+            for (j = 0; j < acb_mat_ncols(dest); j++)
+                _acb_set_fmpq_fmpq(acb_mat_entry(dest, i, j),
+                    fmpq_mat_entry(realsrc, i, j),
+                    fmpq_mat_entry(imagsrc, i, j), prec);
+    }
+}
+
+
 int main()
 {
     slong iter;
@@ -38,8 +91,10 @@ int main()
 
     for (iter = 0; iter < 10000; iter++)
     {
-        slong m, n, k, qbits1, qbits2, rbits1, rbits2, rbits3;
-        fmpq_mat_t A, B, C;
+        slong m, n, k;
+        slong qbits1, qbits2;
+        slong rbits1, rbits2, rbits3;
+        fmpq_mat_t A, B, C, D, E, F, T;
         acb_mat_t a, b, c, d;
 
         qbits1 = 2 + n_randint(state, 200);
@@ -53,8 +108,12 @@ int main()
         k = n_randint(state, 10);
 
         fmpq_mat_init(A, m, n);
-        fmpq_mat_init(B, n, k);
-        fmpq_mat_init(C, m, k);
+        fmpq_mat_init(B, m, n);
+        fmpq_mat_init(C, n, k);
+        fmpq_mat_init(D, n, k);
+        fmpq_mat_init(E, m, k);
+        fmpq_mat_init(F, m, k);
+        fmpq_mat_init(T, m, k);
 
         acb_mat_init(a, m, n);
         acb_mat_init(b, n, k);
@@ -62,14 +121,24 @@ int main()
         acb_mat_init(d, m, k);
 
         fmpq_mat_randtest(A, state, qbits1);
-        fmpq_mat_randtest(B, state, qbits2);
-        fmpq_mat_mul(C, A, B);
+        fmpq_mat_randtest(B, state, qbits1);
+        fmpq_mat_randtest(C, state, qbits2);
+        fmpq_mat_randtest(D, state, qbits2);
 
-        acb_mat_set_fmpq_mat(a, A, rbits1);
-        acb_mat_set_fmpq_mat(b, B, rbits2);
+        /* E, F = AC - BD, AD + BC */
+        fmpq_mat_mul(E, A, C);
+        fmpq_mat_mul(T, B, D);
+        fmpq_mat_sub(E, E, T);
+        fmpq_mat_mul(F, A, D);
+        fmpq_mat_mul(T, B, C);
+        fmpq_mat_add(F, F, T);
+
+        /* a, b = A + B*i, C + D*i */
+        _acb_mat_set_fmpq_mat_fmpq_mat(a, A, B, rbits1);
+        _acb_mat_set_fmpq_mat_fmpq_mat(b, C, D, rbits2);
         acb_mat_mul(c, a, b, rbits3);
 
-        if (!acb_mat_contains_fmpq_mat(c, C))
+        if (!_acb_mat_contains_fmpq_mat_fmpq_mat(c, E, F))
         {
             flint_printf("FAIL\n\n");
             flint_printf("m = %wd, n = %wd, k = %wd, bits3 = %wd\n", m, n, k, rbits3);
@@ -77,6 +146,9 @@ int main()
             flint_printf("A = "); fmpq_mat_print(A); flint_printf("\n\n");
             flint_printf("B = "); fmpq_mat_print(B); flint_printf("\n\n");
             flint_printf("C = "); fmpq_mat_print(C); flint_printf("\n\n");
+            flint_printf("D = "); fmpq_mat_print(D); flint_printf("\n\n");
+            flint_printf("E = "); fmpq_mat_print(E); flint_printf("\n\n");
+            flint_printf("F = "); fmpq_mat_print(F); flint_printf("\n\n");
 
             flint_printf("a = "); acb_mat_printd(a, 15); flint_printf("\n\n");
             flint_printf("b = "); acb_mat_printd(b, 15); flint_printf("\n\n");
@@ -114,6 +186,10 @@ int main()
         fmpq_mat_clear(A);
         fmpq_mat_clear(B);
         fmpq_mat_clear(C);
+        fmpq_mat_clear(D);
+        fmpq_mat_clear(E);
+        fmpq_mat_clear(F);
+        fmpq_mat_clear(T);
 
         acb_mat_clear(a);
         acb_mat_clear(b);


### PR DESCRIPTION
Improve `acb_mat_mul` test coverage. I've left the convenience functions in `acb_mat/test/t-mul.c` instead of cluttering the namespace. They could be moved later, or not.