### PR TITLE
MAINT: explicit cast to avoid comparing signed vs. unsigned

### DIFF
--- a/arb_poly.h
+++ b/arb_poly.h
@@ -660,7 +660,7 @@ poly_pow_length(slong poly_len, ulong exp, slong trunc)
     add_ssaaaa(hi, lo, hi, lo, 0, 1);
     if (hi != 0 || lo > (mp_limb_t) WORD_MAX)
         return trunc;
-    return FLINT_MIN(lo, trunc);
+    return FLINT_MIN((slong) lo, trunc);
 }
 
 #ifndef NEWTON_INIT


### PR DESCRIPTION
This is a small nitpick to get rid of a `-Wsign-compare` compiler warning. I'm not completely sure it's correct, but I think it is.

```
/usr/local/include/flint/flint.h:237:42: warning: signed and unsigned type in co
nditional expression [-Wsign-compare]
 #define FLINT_MIN(x, y) ((x) > (y) ? (y) : (x))
                                          ^
../arb/arb_poly.h:663:12: note: in expansion of macro ‘FLINT_MIN’
     return FLINT_MIN(lo, trunc);
            ^
```