### PR TITLE
ENH: improved structured matrix exp bounds

### DIFF
--- a/acb_mat/test/t-exp.c
+++ b/acb_mat/test/t-exp.c
@@ -25,6 +25,26 @@
 
 #include "acb_mat.h"
 
+void
+_fmpq_mat_randtest_for_exp(fmpq_mat_t mat, flint_rand_t state, mp_bitcnt_t bits)
+{
+    slong i, j;
+    slong l, u;
+    l = n_randint(state, 5);
+    u = n_randint(state, 5);
+    fmpq_mat_zero(mat);
+    for (i = 0; i < fmpq_mat_nrows(mat); i++)
+    {
+        for (j = 0; j < fmpq_mat_ncols(mat); j++)
+        {
+            if ((i == j) || (i < j && u) || (i > j && l))
+            {
+                fmpq_randtest(fmpq_mat_entry(mat, i, j), state, bits);
+            }
+        }
+    }
+}
+
 int main()
 {
     slong iter;
@@ -56,7 +76,7 @@ int main()
         acb_mat_init(EF, n, n);
         acb_mat_init(G, n, n);
 
-        fmpq_mat_randtest(Q, state, qbits);
+        _fmpq_mat_randtest_for_exp(Q, state, qbits);
         acb_mat_set_fmpq_mat(A, Q, prec);
 
         acb_mat_exp(E, A, prec);

--- a/arb_mat/exp.c
+++ b/arb_mat/exp.c
@@ -23,10 +23,98 @@
 
 ******************************************************************************/
 
+#include "fmpz_mat.h"
 #include "double_extras.h"
 #include "arb_mat.h"
 
 #define LOG2_OVER_E 0.25499459743395350926
+
+
+/* Warshall's algorithm */
+void
+_fmpz_mat_transitive_closure(fmpz_mat_t A)
+{
+    slong k, i, j, dim;
+    dim = fmpz_mat_nrows(A);
+
+    if (dim != fmpz_mat_ncols(A))
+    {
+        flint_printf("_fmpz_mat_transitive_closure: a square matrix is required!\n");
+        abort();
+    }
+
+    for (k = 0; k < dim; k++)
+    {
+        for (i = 0; i < dim; i++)
+        {
+            for (j = 0; j < dim; j++)
+            {
+                if (fmpz_is_zero(fmpz_mat_entry(A, i, j)) &&
+                    !fmpz_is_zero(fmpz_mat_entry(A, i, k)) &&
+                    !fmpz_is_zero(fmpz_mat_entry(A, k, j)))
+                {
+                    fmpz_one(fmpz_mat_entry(A, i, j));
+                }
+            }
+        }
+    }
+}
+
+
+int
+_arb_mat_any_is_zero(const arb_mat_t A)
+{
+    slong i, j;
+    for (i = 0; i < arb_mat_nrows(A); i++)
+        for (j = 0; j < arb_mat_ncols(A); j++)
+            if (arb_is_zero(arb_mat_entry(A, i, j)))
+                return 1;
+    return 0;
+}
+
+
+void
+_arb_mat_exp_set_structure(arb_mat_t B, const arb_mat_t A)
+{
+    slong i, j, dim;
+    fmpz_mat_t C;
+
+    dim = arb_mat_nrows(A);
+    fmpz_mat_init(C, dim, dim);
+    fmpz_mat_zero(C);
+    for (i = 0; i < dim; i++)
+    {
+        for (j = 0; j < dim; j++)
+        {
+            if (!arb_is_zero(arb_mat_entry(A, i, j)))
+            {
+                fmpz_one(fmpz_mat_entry(C, i, j));
+            }
+        }
+    }
+
+    _fmpz_mat_transitive_closure(C);
+
+    for (i = 0; i < dim; i++)
+    {
+        for (j = 0; j < dim; j++)
+        {
+            if (fmpz_is_zero(fmpz_mat_entry(C, i, j)))
+            {
+                if (i == j)
+                {
+                    arb_one(arb_mat_entry(B, i, j));
+                }
+                else
+                {
+                    arb_zero(arb_mat_entry(B, i, j));
+                }
+            }
+        }
+    }
+    fmpz_mat_clear(C);
+}
+
 
 slong
 _arb_mat_exp_choose_N(const mag_t norm, slong prec)
@@ -200,6 +288,9 @@ arb_mat_exp(arb_mat_t B, const arb_mat_t A, slong prec)
         for (i = 0; i < dim; i++)
             for (j = 0; j < dim; j++)
                 arb_add_error_mag(arb_mat_entry(B, i, j), err);
+
+        if (_arb_mat_any_is_zero(A))
+            _arb_mat_exp_set_structure(B, A);
 
         for (i = 0; i < r; i++)
         {

--- a/arb_mat/test/t-exp.c
+++ b/arb_mat/test/t-exp.c
@@ -25,6 +25,26 @@
 
 #include "arb_mat.h"
 
+void
+_fmpq_mat_randtest_for_exp(fmpq_mat_t mat, flint_rand_t state, mp_bitcnt_t bits)
+{
+    slong i, j;
+    slong l, u;
+    l = n_randint(state, 5);
+    u = n_randint(state, 5);
+    fmpq_mat_zero(mat);
+    for (i = 0; i < fmpq_mat_nrows(mat); i++)
+    {
+        for (j = 0; j < fmpq_mat_ncols(mat); j++)
+        {
+            if ((i == j) || (i < j && u) || (i > j && l))
+            {
+                fmpq_randtest(fmpq_mat_entry(mat, i, j), state, bits);
+            }
+        }
+    }
+}
+
 int main()
 {
     slong iter;
@@ -56,7 +76,7 @@ int main()
         arb_mat_init(EF, n, n);
         arb_mat_init(G, n, n);
 
-        fmpq_mat_randtest(Q, state, qbits);
+        _fmpq_mat_randtest_for_exp(Q, state, qbits);
         arb_mat_set_fmpq_mat(A, Q, prec);
 
         arb_mat_exp(E, A, prec);

--- a/doc/source/arb_mat.rst
+++ b/doc/source/arb_mat.rst
@@ -317,6 +317,8 @@ Special functions
           \sum_{k=N}^{\infty} \frac{(2^{-r} \|A\|_{\infty})^k}{k!}.
 
     We bound the sum on the right using :func:`mag_exp_tail`.
+    Truncation error is not added to entries whose values are determined
+    by the sparsity structure of `A`.
 
 .. function:: void arb_mat_trace(arb_t trace, const arb_mat_t mat, slong prec)
 


### PR DESCRIPTION
This PR improves `exp` bounds for matrices that have a structure that is unaffected by taking matrix powers. Examples include diagonal, triangular, or block matrices, possibly under permutation.  This improvement is achieved by detecting matrix entries that are structurally determined and not adding Taylor series truncation errors to these entries. There shouldn't be too much overhead for matrices without this structure.

For structured matrices the `exp` calculation not only has improved bounds, but is also computed faster. The reason for the speedup is that intermediate matrices in the squaring step of 'scaling and squaring' used to have a nontrivial error radius for every matrix entry, whereas after this PR some of these entries have zero error radius.

No new tests have been added, and it's not implemented for `acb` matrices. The existing random matrix fuzz tester for `exp` already generates matrices that have enough structure to provide some test coverage of this PR.