### PR TITLE
MAINT: document sparsity-related arb_mat functions and move them to a separate file

### DIFF
--- a/arb_mat.h
+++ b/arb_mat.h
@@ -301,21 +301,20 @@ void arb_mat_trace(arb_t trace, const arb_mat_t mat, slong prec);
 
 /* Sparsity structure */
 
-void _arb_mat_entrywise_nonzero_round_up(fmpz_mat_t A, const arb_mat_t src);
+void arb_mat_entrywise_is_zero(fmpz_mat_t dest, const arb_mat_t src);
 
-ARB_MAT_INLINE void
-arb_mat_adjacency(fmpz_mat_t A, const arb_mat_t src)
-{
-    _arb_mat_entrywise_nonzero_round_up(A, src);
-}
+void arb_mat_entrywise_not_is_zero(fmpz_mat_t dest, const arb_mat_t src);
 
-slong _arb_mat_count_nonzero_round_up(const arb_mat_t src);
+slong arb_mat_count_is_zero(const arb_mat_t mat);
 
 ARB_MAT_INLINE slong
-arb_mat_count_nonzero(const arb_mat_t src)
+arb_mat_count_not_is_zero(const arb_mat_t mat)
 {
-    return  _arb_mat_count_nonzero_round_up(src);
+    slong size;
+    size = arb_mat_nrows(mat) * arb_mat_ncols(mat);
+    return size - arb_mat_count_is_zero(mat);
 }
+
 
 #ifdef __cplusplus
 }

--- a/arb_mat.h
+++ b/arb_mat.h
@@ -299,6 +299,24 @@ void arb_mat_charpoly(arb_poly_t cp, const arb_mat_t mat, slong prec);
 
 void arb_mat_trace(arb_t trace, const arb_mat_t mat, slong prec);
 
+/* Sparsity structure */
+
+void _arb_mat_entrywise_nonzero_round_up(fmpz_mat_t A, const arb_mat_t src);
+
+ARB_MAT_INLINE void
+arb_mat_adjacency(fmpz_mat_t A, const arb_mat_t src)
+{
+    _arb_mat_entrywise_nonzero_round_up(A, src);
+}
+
+slong _arb_mat_count_nonzero_round_up(const arb_mat_t src);
+
+ARB_MAT_INLINE slong
+arb_mat_count_nonzero(const arb_mat_t src)
+{
+    return  _arb_mat_count_nonzero_round_up(src);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/arb_mat/adjacency.c
+++ b/arb_mat/adjacency.c
@@ -1,0 +1,62 @@
+/*=============================================================================
+
+    This file is part of ARB.
+
+    ARB is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    ARB is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FLINT; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2016 Arb authors
+
+******************************************************************************/
+
+#include "arb_mat.h"
+
+void
+_arb_mat_entrywise_nonzero_round_up(fmpz_mat_t A, const arb_mat_t src)
+{
+    slong i, j;
+    fmpz_mat_zero(A);
+    for (i = 0; i < arb_mat_nrows(src); i++)
+    {
+        for (j = 0; j < arb_mat_ncols(src); j++)
+        {
+            if (!arb_is_zero(arb_mat_entry(src, i, j)))
+            {
+                fmpz_one(fmpz_mat_entry(A, i, j));
+            }
+        }
+    }
+}
+
+slong
+_arb_mat_count_nonzero_round_up(const arb_mat_t src)
+{
+    slong nnz;
+    slong i, j;
+    nnz = 0;
+    for (i = 0; i < arb_mat_nrows(src); i++)
+    {
+        for (j = 0; j < arb_mat_ncols(src); j++)
+        {
+            if (!arb_is_zero(arb_mat_entry(src, i, j)))
+            {
+                nnz++;
+            }
+        }
+    }
+    return nnz;
+}

--- a/arb_mat/count_is_zero.c
+++ b/arb_mat/count_is_zero.c
@@ -1,0 +1,45 @@
+/*=============================================================================
+
+    This file is part of ARB.
+
+    ARB is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    ARB is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FLINT; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2016 Arb authors
+
+******************************************************************************/
+
+#include "arb_mat.h"
+
+slong
+arb_mat_count_is_zero(const arb_mat_t mat)
+{
+    slong nz;
+    slong i, j;
+    nz = 0;
+    for (i = 0; i < arb_mat_nrows(mat); i++)
+    {
+        for (j = 0; j < arb_mat_ncols(mat); j++)
+        {
+            if (arb_is_zero(arb_mat_entry(mat, i, j)))
+            {
+                nz++;
+            }
+        }
+    }
+    return nz;
+}

--- a/arb_mat/entrywise_is_zero.c
+++ b/arb_mat/entrywise_is_zero.c
@@ -26,37 +26,18 @@
 #include "arb_mat.h"
 
 void
-_arb_mat_entrywise_nonzero_round_up(fmpz_mat_t A, const arb_mat_t src)
+_arb_mat_entrywise_is_zero(fmpz_mat_t dest, const arb_mat_t src)
 {
     slong i, j;
-    fmpz_mat_zero(A);
+    fmpz_mat_zero(dest);
     for (i = 0; i < arb_mat_nrows(src); i++)
     {
         for (j = 0; j < arb_mat_ncols(src); j++)
         {
-            if (!arb_is_zero(arb_mat_entry(src, i, j)))
+            if (arb_is_zero(arb_mat_entry(src, i, j)))
             {
-                fmpz_one(fmpz_mat_entry(A, i, j));
+                fmpz_one(fmpz_mat_entry(dest, i, j));
             }
         }
     }
-}
-
-slong
-_arb_mat_count_nonzero_round_up(const arb_mat_t src)
-{
-    slong nnz;
-    slong i, j;
-    nnz = 0;
-    for (i = 0; i < arb_mat_nrows(src); i++)
-    {
-        for (j = 0; j < arb_mat_ncols(src); j++)
-        {
-            if (!arb_is_zero(arb_mat_entry(src, i, j)))
-            {
-                nnz++;
-            }
-        }
-    }
-    return nnz;
 }

--- a/arb_mat/entrywise_not_is_zero.c
+++ b/arb_mat/entrywise_not_is_zero.c
@@ -1,0 +1,43 @@
+/*=============================================================================
+
+    This file is part of ARB.
+
+    ARB is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    ARB is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FLINT; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2016 Arb authors
+
+******************************************************************************/
+
+#include "arb_mat.h"
+
+void
+arb_mat_entrywise_not_is_zero(fmpz_mat_t dest, const arb_mat_t src)
+{
+    slong i, j;
+    fmpz_mat_zero(dest);
+    for (i = 0; i < arb_mat_nrows(src); i++)
+    {
+        for (j = 0; j < arb_mat_ncols(src); j++)
+        {
+            if (!arb_is_zero(arb_mat_entry(src, i, j)))
+            {
+                fmpz_one(fmpz_mat_entry(dest, i, j));
+            }
+        }
+    }
+}

--- a/arb_mat/exp.c
+++ b/arb_mat/exp.c
@@ -270,11 +270,11 @@ arb_mat_exp(arb_mat_t B, const arb_mat_t A, slong prec)
         fmpz_mat_t S;
         int using_structure;
 
-        using_structure = arb_mat_count_nonzero(A) < dim * dim;
+        using_structure = arb_mat_count_is_zero(A) > 0;
         if (using_structure)
         {
             fmpz_mat_init(S, dim, dim);
-            arb_mat_adjacency(S, A);
+            arb_mat_entrywise_not_is_zero(S, A);
             _fmpz_mat_transitive_closure(S, S);
         }
 

--- a/arb_mat/exp.c
+++ b/arb_mat/exp.c
@@ -32,7 +32,7 @@
 
 /* Warshall's algorithm */
 void
-_fmpz_mat_transitive_closure(fmpz_mat_t A)
+_fmpz_mat_transitive_closure(fmpz_mat_t B, fmpz_mat_t A)
 {
     slong k, i, j, dim;
     dim = fmpz_mat_nrows(A);
@@ -43,17 +43,22 @@ _fmpz_mat_transitive_closure(fmpz_mat_t A)
         abort();
     }
 
+    if (A != B)
+    {
+        fmpz_mat_set(B, A);
+    }
+
     for (k = 0; k < dim; k++)
     {
         for (i = 0; i < dim; i++)
         {
             for (j = 0; j < dim; j++)
             {
-                if (fmpz_is_zero(fmpz_mat_entry(A, i, j)) &&
-                    !fmpz_is_zero(fmpz_mat_entry(A, i, k)) &&
-                    !fmpz_is_zero(fmpz_mat_entry(A, k, j)))
+                if (fmpz_is_zero(fmpz_mat_entry(B, i, j)) &&
+                    !fmpz_is_zero(fmpz_mat_entry(B, i, k)) &&
+                    !fmpz_is_zero(fmpz_mat_entry(B, k, j)))
                 {
-                    fmpz_one(fmpz_mat_entry(A, i, j));
+                    fmpz_one(fmpz_mat_entry(B, i, j));
                 }
             }
         }
@@ -69,37 +74,6 @@ _arb_mat_is_diagonal(const arb_mat_t A)
             if (i != j && !arb_is_zero(arb_mat_entry(A, i, j)))
                 return 0;
     return 1;
-}
-
-int
-_arb_mat_any_is_zero(const arb_mat_t A)
-{
-    slong i, j;
-    for (i = 0; i < arb_mat_nrows(A); i++)
-        for (j = 0; j < arb_mat_ncols(A); j++)
-            if (arb_is_zero(arb_mat_entry(A, i, j)))
-                return 1;
-    return 0;
-}
-
-void
-_arb_mat_exp_get_structure(fmpz_mat_t C, const arb_mat_t A)
-{
-    slong i, j, dim;
-
-    dim = arb_mat_nrows(A);
-    fmpz_mat_zero(C);
-    for (i = 0; i < dim; i++)
-    {
-        for (j = 0; j < dim; j++)
-        {
-            if (!arb_is_zero(arb_mat_entry(A, i, j)))
-            {
-                fmpz_one(fmpz_mat_entry(C, i, j));
-            }
-        }
-    }
-    _fmpz_mat_transitive_closure(C);
 }
 
 void
@@ -296,11 +270,12 @@ arb_mat_exp(arb_mat_t B, const arb_mat_t A, slong prec)
         fmpz_mat_t S;
         int using_structure;
 
-        using_structure = _arb_mat_any_is_zero(A);
+        using_structure = arb_mat_count_nonzero(A) < dim * dim;
         if (using_structure)
         {
             fmpz_mat_init(S, dim, dim);
-            _arb_mat_exp_get_structure(S, A);
+            arb_mat_adjacency(S, A);
+            _fmpz_mat_transitive_closure(S, S);
         }
 
         q = pow(wp, 0.25);  /* wanted magnitude */

--- a/doc/source/arb_mat.rst
+++ b/doc/source/arb_mat.rst
@@ -324,3 +324,19 @@ Special functions
 
     Sets *trace* to the trace of the matrix, i.e. the sum of entries on the
     main diagonal of *mat*. The matrix is required to be square.
+
+Sparsity structure
+-------------------------------------------------------------------------------
+
+.. function:: void _arb_mat_entrywise_nonzero_round_up(fmpz_mat_t A, const arb_mat_t src)
+
+.. function:: void arb_mat_adjacency(fmpz_mat_t A, const arb_mat_t src)
+
+    Each entry of *A* is set to 0 or 1 depending on whether or not
+    the corresponding entry of *src* is zero.
+
+.. function:: slong _arb_mat_count_nonzero_round_up(const arb_mat_t src)
+
+.. function:: slong arb_mat_count_nonzero(const arb_mat_t src)
+
+    Returns the number of nonzero entries of the matrix.

--- a/doc/source/arb_mat.rst
+++ b/doc/source/arb_mat.rst
@@ -328,15 +328,25 @@ Special functions
 Sparsity structure
 -------------------------------------------------------------------------------
 
-.. function:: void _arb_mat_entrywise_nonzero_round_up(fmpz_mat_t A, const arb_mat_t src)
+.. function:: void arb_mat_entrywise_is_zero(fmpz_mat_t dest, const arb_mat_t src)
 
-.. function:: void arb_mat_adjacency(fmpz_mat_t A, const arb_mat_t src)
+    Sets each entry of *dest* to indicate whether the corresponding
+    entry of *src* is certainly zero.
+    If the entry of *src* at row `i` and column `j` is zero according to
+    :func:`arb_is_zero` then the entry of *dest* at that row and column
+    is set to one, otherwise that entry of *dest* is set to zero.
 
-    Each entry of *A* is set to 0 or 1 depending on whether or not
-    the corresponding entry of *src* is zero.
+.. function:: void arb_mat_entrywise_not_is_zero(fmpz_mat_t dest, const arb_mat_t src)
 
-.. function:: slong _arb_mat_count_nonzero_round_up(const arb_mat_t src)
+    Sets each entry of *dest* to indicate whether the corresponding
+    entry of *src* is not certainly zero.
+    This the complement of :func:`arb_mat_entrywise_is_zero`.
 
-.. function:: slong arb_mat_count_nonzero(const arb_mat_t src)
+.. function:: slong arb_mat_count_is_zero(const arb_mat_t mat)
 
-    Returns the number of nonzero entries of the matrix.
+    Returns the number of entries of *mat* that are certainly zero
+    according to :func:`arb_is_zero`.
+
+.. function:: slong arb_mat_count_not_is_zero(const arb_mat_t mat)
+
+    Returns the number of entries of *mat* that are not certainly zero.


### PR DESCRIPTION
This PR only adds docs and reorganizes code, and it should not affect the behavior of existing public functions.

It adds the new file `arb_mat/adjacency.c` containing `_arb_mat_entrywise_nonzero_round_up` and `_arb_mat_count_nonzero_round_up` which are wrapped in the header file by `arb_mat_adjacency` and `arb_mat_count_nonzero`. This breaks the existing `arb_mat` convention of 1:1 correspondence between public function names and .c file names, so if that convention is important then this PR should not be merged as-is.

This PR has not included analogous changes to `acb_mat`.