### PR TITLE
ENH: use sparsity structure more intelligently for matrix power series

### DIFF
--- a/acb_mat.h
+++ b/acb_mat.h
@@ -94,6 +94,18 @@ void acb_mat_set_arb_mat(acb_mat_t dest, const arb_mat_t src);
 
 void acb_mat_set_round_arb_mat(acb_mat_t dest, const arb_mat_t src, slong prec);
 
+ACB_MAT_INLINE int
+acb_mat_is_empty(const acb_mat_t mat)
+{
+    return (mat->r == 0) || (mat->c == 0);
+}
+
+ACB_MAT_INLINE int
+acb_mat_is_square(const acb_mat_t mat)
+{
+    return (mat->r == mat->c);
+}
+
 /* Random generation */
 
 void acb_mat_randtest(acb_mat_t mat, flint_rand_t state, slong prec, slong mag_bits);

--- a/acb_mat.h
+++ b/acb_mat.h
@@ -333,6 +333,22 @@ void acb_mat_charpoly(acb_poly_t cp, const acb_mat_t mat, slong prec);
 
 void acb_mat_trace(acb_t trace, const acb_mat_t mat, slong prec);
 
+/* Sparsity structure */
+
+void acb_mat_entrywise_is_zero(fmpz_mat_t dest, const acb_mat_t src);
+
+void acb_mat_entrywise_not_is_zero(fmpz_mat_t dest, const acb_mat_t src);
+
+slong acb_mat_count_is_zero(const acb_mat_t mat);
+
+ARB_MAT_INLINE slong
+acb_mat_count_not_is_zero(const acb_mat_t mat)
+{
+    slong size;
+    size = acb_mat_nrows(mat) * acb_mat_ncols(mat);
+    return size - acb_mat_count_is_zero(mat);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/acb_mat/count_is_zero.c
+++ b/acb_mat/count_is_zero.c
@@ -1,0 +1,45 @@
+/*=============================================================================
+
+    This file is part of ARB.
+
+    ARB is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    ARB is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FLINT; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2016 Arb authors
+
+******************************************************************************/
+
+#include "acb_mat.h"
+
+slong
+acb_mat_count_is_zero(const acb_mat_t mat)
+{
+    slong nz;
+    slong i, j;
+    nz = 0;
+    for (i = 0; i < acb_mat_nrows(mat); i++)
+    {
+        for (j = 0; j < acb_mat_ncols(mat); j++)
+        {
+            if (acb_is_zero(acb_mat_entry(mat, i, j)))
+            {
+                nz++;
+            }
+        }
+    }
+    return nz;
+}

--- a/acb_mat/entrywise_is_zero.c
+++ b/acb_mat/entrywise_is_zero.c
@@ -1,0 +1,43 @@
+/*=============================================================================
+
+    This file is part of ARB.
+
+    ARB is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    ARB is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FLINT; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2016 Arb authors
+
+******************************************************************************/
+
+#include "acb_mat.h"
+
+void
+_acb_mat_entrywise_is_zero(fmpz_mat_t dest, const acb_mat_t src)
+{
+    slong i, j;
+    fmpz_mat_zero(dest);
+    for (i = 0; i < acb_mat_nrows(src); i++)
+    {
+        for (j = 0; j < acb_mat_ncols(src); j++)
+        {
+            if (acb_is_zero(acb_mat_entry(src, i, j)))
+            {
+                fmpz_one(fmpz_mat_entry(dest, i, j));
+            }
+        }
+    }
+}

--- a/acb_mat/entrywise_not_is_zero.c
+++ b/acb_mat/entrywise_not_is_zero.c
@@ -1,0 +1,43 @@
+/*=============================================================================
+
+    This file is part of ARB.
+
+    ARB is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    ARB is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FLINT; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2016 Arb authors
+
+******************************************************************************/
+
+#include "acb_mat.h"
+
+void
+acb_mat_entrywise_not_is_zero(fmpz_mat_t dest, const acb_mat_t src)
+{
+    slong i, j;
+    fmpz_mat_zero(dest);
+    for (i = 0; i < acb_mat_nrows(src); i++)
+    {
+        for (j = 0; j < acb_mat_ncols(src); j++)
+        {
+            if (!acb_is_zero(acb_mat_entry(src, i, j)))
+            {
+                fmpz_one(fmpz_mat_entry(dest, i, j));
+            }
+        }
+    }
+}

--- a/acb_mat/exp.c
+++ b/acb_mat/exp.c
@@ -194,7 +194,8 @@ acb_mat_exp(acb_mat_t B, const acb_mat_t A, slong prec)
         {
             fmpz_mat_init(S, dim, dim);
             acb_mat_entrywise_not_is_zero(S, A);
-            fmpz_mat_entrywise_nilpotence_degree(S, S);
+            fmpz_mat_unweighted_all_pairs_longest_walk(S, S);
+            fmpz_mat_add_ui_entrywise(S, S, 1);
         }
 
         q = pow(wp, 0.25);  /* wanted magnitude */

--- a/acb_mat/test/t-exp.c
+++ b/acb_mat/test/t-exp.c
@@ -29,7 +29,8 @@ void
 _fmpq_mat_randtest_for_exp(fmpq_mat_t mat, flint_rand_t state, mp_bitcnt_t bits)
 {
     slong i, j;
-    slong l, u;
+    slong d, l, u;
+    d = n_randint(state, 5);
     l = n_randint(state, 5);
     u = n_randint(state, 5);
     fmpq_mat_zero(mat);
@@ -37,7 +38,7 @@ _fmpq_mat_randtest_for_exp(fmpq_mat_t mat, flint_rand_t state, mp_bitcnt_t bits)
     {
         for (j = 0; j < fmpq_mat_ncols(mat); j++)
         {
-            if ((i == j) || (i < j && u) || (i > j && l))
+            if ((i == j && d) || (i < j && u) || (i > j && l))
             {
                 fmpq_randtest(fmpq_mat_entry(mat, i, j), state, bits);
             }

--- a/arb_mat.h
+++ b/arb_mat.h
@@ -118,6 +118,18 @@ int arb_mat_contains_fmpq_mat(const arb_mat_t mat1, const fmpq_mat_t mat2);
 
 int arb_mat_contains_fmpz_mat(const arb_mat_t mat1, const fmpz_mat_t mat2);
 
+ARB_MAT_INLINE int
+arb_mat_is_empty(const arb_mat_t mat)
+{
+    return (mat->r == 0) || (mat->c == 0);
+}
+
+ARB_MAT_INLINE int
+arb_mat_is_square(const arb_mat_t mat)
+{
+    return (mat->r == mat->c);
+}
+
 /* Special matrices */
 
 void arb_mat_zero(arb_mat_t mat);

--- a/arb_mat/exp.c
+++ b/arb_mat/exp.c
@@ -235,7 +235,8 @@ arb_mat_exp(arb_mat_t B, const arb_mat_t A, slong prec)
         {
             fmpz_mat_init(S, dim, dim);
             arb_mat_entrywise_not_is_zero(S, A);
-            fmpz_mat_entrywise_nilpotence_degree(S, S);
+            fmpz_mat_unweighted_all_pairs_longest_walk(S, S);
+            fmpz_mat_add_ui_entrywise(S, S, 1);
         }
 
         q = pow(wp, 0.25);  /* wanted magnitude */

--- a/arb_mat/exp.c
+++ b/arb_mat/exp.c
@@ -30,6 +30,26 @@
 
 #define LOG2_OVER_E 0.25499459743395350926
 
+slong
+_fmpz_mat_max_si(const fmpz_mat_t A)
+{
+    slong i, j, x;
+
+    /* empty max is undefined */
+    if (fmpz_mat_is_empty(A)) abort(); /* assert */
+
+    x = fmpz_get_si(fmpz_mat_entry(A, 0, 0));
+    for (i = 0; i < fmpz_mat_nrows(A); i++)
+    {
+        for (j = 0; j < fmpz_mat_ncols(A); j++)
+        {
+            x = FLINT_MAX(x, fmpz_get_si(fmpz_mat_entry(A, i, j)));
+        }
+    }
+
+    return x;
+}
+
 int
 _arb_mat_is_diagonal(const arb_mat_t A)
 {
@@ -231,6 +251,13 @@ arb_mat_exp(arb_mat_t B, const arb_mat_t A, slong prec)
         mag_mul_2exp_si(norm, norm, -r);
 
         N = _arb_mat_exp_choose_N(norm, wp);
+
+        /* get a second opinion if the matrix is nilpotent */
+        if (using_structure && fmpz_mat_is_nonnegative(S))
+        {
+            N = FLINT_MIN(N, _fmpz_mat_max_si(S));
+        }
+
         mag_exp_tail(err, norm, N);
 
         _arb_mat_exp_taylor(B, T, N, wp);

--- a/arb_mat/test/t-exp.c
+++ b/arb_mat/test/t-exp.c
@@ -29,7 +29,8 @@ void
 _fmpq_mat_randtest_for_exp(fmpq_mat_t mat, flint_rand_t state, mp_bitcnt_t bits)
 {
     slong i, j;
-    slong l, u;
+    slong d, l, u;
+    d = n_randint(state, 5);
     l = n_randint(state, 5);
     u = n_randint(state, 5);
     fmpq_mat_zero(mat);
@@ -37,7 +38,7 @@ _fmpq_mat_randtest_for_exp(fmpq_mat_t mat, flint_rand_t state, mp_bitcnt_t bits)
     {
         for (j = 0; j < fmpq_mat_ncols(mat); j++)
         {
-            if ((i == j) || (i < j && u) || (i > j && l))
+            if ((i == j && d) || (i < j && u) || (i > j && l))
             {
                 fmpq_randtest(fmpq_mat_entry(mat, i, j), state, bits);
             }

--- a/doc/source/acb_mat.rst
+++ b/doc/source/acb_mat.rst
@@ -320,3 +320,29 @@ Special functions
 
     Sets *trace* to the trace of the matrix, i.e. the sum of entries on the
     main diagonal of *mat*. The matrix is required to be square.
+
+Sparsity structure
+-------------------------------------------------------------------------------
+
+.. function:: void acb_mat_entrywise_is_zero(fmpz_mat_t dest, const acb_mat_t src)
+
+    Sets each entry of *dest* to indicate whether the corresponding
+    entry of *src* is certainly zero.
+    If the entry of *src* at row `i` and column `j` is zero according to
+    :func:`acb_is_zero` then the entry of *dest* at that row and column
+    is set to one, otherwise that entry of *dest* is set to zero.
+
+.. function:: void acb_mat_entrywise_not_is_zero(fmpz_mat_t dest, const acb_mat_t src)
+
+    Sets each entry of *dest* to indicate whether the corresponding
+    entry of *src* is not certainly zero.
+    This the complement of :func:`acb_mat_entrywise_is_zero`.
+
+.. function:: slong acb_mat_count_is_zero(const acb_mat_t mat)
+
+    Returns the number of entries of *mat* that are certainly zero
+    according to :func:`acb_is_zero`.
+
+.. function:: slong acb_mat_count_not_is_zero(const acb_mat_t mat)
+
+    Returns the number of entries of *mat* that are not certainly zero.

--- a/doc/source/acb_mat.rst
+++ b/doc/source/acb_mat.rst
@@ -120,6 +120,14 @@ Comparisons
 
     Returns nonzero iff *mat1* and *mat2* certainly do not represent the same matrix.
 
+.. function:: int acb_mat_is_empty(const acb_mat_t mat)
+
+    Returns nonzero iff the number of rows or the number of columns in *mat* is zero.
+
+.. function:: int acb_mat_is_square(const acb_mat_t mat)
+
+    Returns nonzero iff the number of rows is equal to the number of columns in *mat*.
+
 .. function:: int acb_mat_is_real(const acb_mat_t mat)
 
     Returns nonzero iff all entries in *mat* have zero imaginary part.

--- a/doc/source/arb_mat.rst
+++ b/doc/source/arb_mat.rst
@@ -116,6 +116,14 @@ Comparisons
 
     Returns nonzero iff *mat1* and *mat2* certainly do not represent the same matrix.
 
+.. function:: int arb_mat_is_empty(const arb_mat_t mat)
+
+    Returns nonzero iff the number of rows or the number of columns in *mat* is zero.
+
+.. function:: int arb_mat_is_square(const arb_mat_t mat)
+
+    Returns nonzero iff the number of rows is equal to the number of columns in *mat*.
+
 Special matrices
 -------------------------------------------------------------------------------
 

--- a/doc/source/fmpz_mat_extras.rst
+++ b/doc/source/fmpz_mat_extras.rst
@@ -7,58 +7,68 @@ This module implements a few utility methods for the FLINT
 multiprecision integer matrix type (*fmpz_mat_t*).
 It is mainly intended for internal use.
 
-Convenience methods
+
+Comparison
 -------------------------------------------------------------------------------
 
-.. function:: int fmpz_mat_is_hollow(const fmpz_mat_t mat);
+.. function:: int fmpz_mat_is_hollow(const fmpz_mat_t mat)
 
     Returns a non-zero value if all entries on the diagonal of *mat* are zero,
     and otherwise returns zero.
 
-.. function:: int fmpz_mat_is_nonnegative(const fmpz_mat_t mat);
+.. function:: int fmpz_mat_is_nonnegative(const fmpz_mat_t mat)
 
     Returns a non-zero value if all entries of *mat* are non-negative,
     and otherwise returns zero.
 
-.. function:: int fmpz_mat_is_lower_triangular(const fmpz_mat_t mat);
+.. function:: int fmpz_mat_is_lower_triangular(const fmpz_mat_t mat)
 
     Returns a non-zero value if every entry that is not in the
     lower triangular region of *mat* is zero, and otherwise returns zero.
     The entry at row `i` and column `j` is in the lower triangular region
-    if `i >= j`.
+    if `i \ge j`.
 
-.. function:: void fmpz_mat_entrywise_not_is_zero(fmpz_mat_t dest, const fmpz_mat_t src);
+.. function:: void fmpz_mat_entrywise_not_is_zero(fmpz_mat_t dest, const fmpz_mat_t src)
 
     Sets each entry in *dest* to zero or one according to whether
     or not the corresponding entry in *src* is zero.
 
-.. function:: void fmpz_mat_transitive_closure(fmpz_mat_t dest, const fmpz_mat_t src);
 
-    Sets each entry of *dest* to a non-zero value or zero depending
-    on whether or not the entry is in the transitive closure of *src*.
-    Letting `A` denote the entrywise absolute value of *src*,
-    the entry of *dest* at row `i` and column `j` is set to a non-zero
-    value if there exists a positive `k` such that the entry in `A^k`
-    at row `i` and column `j` is non-zero.
-    The *src* matrix must be square.
+Arithmetic
+-------------------------------------------------------------------------------
 
-    Graph-theoretically, this function can be interpreted as computing
-    the reachability of `j` from `i` in a graph encoded by *src*.
+.. function:: void fmpz_mat_add_ui_entrywise(fmpz_mat_t B, const fmpz_mat_t A, ulong x)
 
-.. function:: void fmpz_mat_entrywise_nilpotence_degree(fmpz_mat_t B, const fmpz_mat_t A);
+    Sets `B_{ij}` to `A_{ij} + x` where `x` is an ulong.
 
-    Sets the entry in *B* at row `i` and column `j`
-    to the smallest non-negative integer `k` such that the entry in `A^N`
-    at row `i` and column `j` is zero for all `N >= k`.
-    If no such `k` exists, then the entry in *B* at that row and column
-    is set to a negative value.
+.. function:: void fmpz_mat_sub_ui_entrywise(fmpz_mat_t B, const fmpz_mat_t A, ulong x)
 
-    If the matrix *B* computed by this function is non-negative
-    then this means that *A* is nilpotent.
+    Sets `B_{ij}` to `A_{ij} - x` where `x` is an ulong.
 
-    This function is implemented only for non-negative square matrices.
 
-    Graph-theoretically, this function can be interpreted as computing
-    one plus the longest walk length from `i` to `j` in a graph encoded
-    by *src*, with negative values representing infinite walk lengths
-    and values of zero or one indicating that no walk exists.
+Graph theory
+-------------------------------------------------------------------------------
+
+.. function:: void fmpz_mat_transitive_closure(fmpz_mat_t B, const fmpz_mat_t A)
+
+    Given the adjacency matrix *A* of an unweighted directed graph `G`,
+    *B* is set to the adjacency matrix of the transitive closure of `G`.
+    In particular, `B_{st}` is set to a non-zero value if there is a non-empty
+    walk from `s` to `t` in `G`, and otherwise `B_{st}` is set to zero.
+
+.. function:: void fmpz_mat_unweighted_all_pairs_longest_walk(fmpz_mat_t B, const fmpz_mat_t A)
+
+    Given the adjacency matrix *A* of an unweighted directed graph `G`,
+    `B_{st}` is set to the length of the longest walk from `s` to `t` in `G`.
+    Empty walks are considered, so for each vertex `s` there is a zero-length
+    walk from `s` to `s`.  If `t` is unreachable from `s` then `B_{st}`
+    is set to the special value `-1`.  If `G` contains a cycle then arbitrarily
+    long walks may exist; if the length of the longest walk from `s` to `t`
+    is unbounded then `B_{st}` is set to the special value `-2`.
+
+    This function can help quantify entrywise errors in a truncated evaluation
+    of a matrix power series.  If *A* is an indictor matrix with the same
+    sparsity pattern as a matrix `M`, and if `B_{ij}` does not take
+    the special value `-2`, then the tail
+    `\left[ \sum_{k=N}^\infty a_k M^k \right]_{ij}`
+    vanishes when `N > B_{ij}`.

--- a/doc/source/fmpz_mat_extras.rst
+++ b/doc/source/fmpz_mat_extras.rst
@@ -53,7 +53,7 @@ Convenience methods
     If no such `k` exists, then the entry in *B* at that row and column
     is set to a negative value.
 
-    If the matrix *B* computed by this function contains any negative value,
+    If the matrix *B* computed by this function is non-negative
     then this means that *A* is nilpotent.
 
     This function is implemented only for non-negative square matrices.

--- a/doc/source/fmpz_mat_extras.rst
+++ b/doc/source/fmpz_mat_extras.rst
@@ -1,0 +1,64 @@
+.. _fmpz_mat_extras:
+
+**fmpz_mat_extras.h** -- extra methods for FLINT integer matrices
+===============================================================================
+
+This module implements a few utility methods for the FLINT
+multiprecision integer matrix type (*fmpz_mat_t*).
+It is mainly intended for internal use.
+
+Convenience methods
+-------------------------------------------------------------------------------
+
+.. function:: int fmpz_mat_is_hollow(const fmpz_mat_t mat);
+
+    Returns a non-zero value if all entries on the diagonal of *mat* are zero,
+    and otherwise returns zero.
+
+.. function:: int fmpz_mat_is_nonnegative(const fmpz_mat_t mat);
+
+    Returns a non-zero value if all entries of *mat* are non-negative,
+    and otherwise returns zero.
+
+.. function:: int fmpz_mat_is_lower_triangular(const fmpz_mat_t mat);
+
+    Returns a non-zero value if every entry that is not in the
+    lower triangular region of *mat* is zero, and otherwise returns zero.
+    The entry at row `i` and column `j` is in the lower triangular region
+    if `i >= j`.
+
+.. function:: void fmpz_mat_entrywise_not_is_zero(fmpz_mat_t dest, const fmpz_mat_t src);
+
+    Sets each entry in *dest* to zero or one according to whether
+    or not the corresponding entry in *src* is zero.
+
+.. function:: void fmpz_mat_transitive_closure(fmpz_mat_t dest, const fmpz_mat_t src);
+
+    Sets each entry of *dest* to a non-zero value or zero depending
+    on whether or not the entry is in the transitive closure of *src*.
+    Letting `A` denote the entrywise absolute value of *src*,
+    the entry of *dest* at row `i` and column `j` is set to a non-zero
+    value if there exists a positive `k` such that the entry in `A^k`
+    at row `i` and column `j` is non-zero.
+    The *src* matrix must be square.
+
+    Graph-theoretically, this function can be interpreted as computing
+    the reachability of `j` from `i` in a graph encoded by *src*.
+
+.. function:: void fmpz_mat_entrywise_nilpotence_degree(fmpz_mat_t B, const fmpz_mat_t A);
+
+    Sets the entry in *B* at row `i` and column `j`
+    to the smallest non-negative integer `k` such that the entry in `A^N`
+    at row `i` and column `j` is zero for all `N >= k`.
+    If no such `k` exists, then the entry in *B* at that row and column
+    is set to a negative value.
+
+    If the matrix *B* computed by this function contains any negative value,
+    then this means that *A* is nilpotent.
+
+    This function is implemented only for non-negative square matrices.
+
+    Graph-theoretically, this function can be interpreted as computing
+    one plus the longest walk length from `i` to `j` in a graph encoded
+    by *src*, with negative values representing infinite walk lengths
+    and values of zero or one indicating that no walk exists.

--- a/doc/source/fmpz_mat_extras.rst
+++ b/doc/source/fmpz_mat_extras.rst
@@ -8,13 +8,18 @@ multiprecision integer matrix type (*fmpz_mat_t*).
 It is mainly intended for internal use.
 
 
-Comparison
+Convenience functions related to sparsity structure
 -------------------------------------------------------------------------------
 
 .. function:: int fmpz_mat_is_hollow(const fmpz_mat_t mat)
 
     Returns a non-zero value if all entries on the diagonal of *mat* are zero,
     and otherwise returns zero.
+
+.. function:: int fmpz_mat_is_diagonal(const fmpz_mat_t mat)
+
+    Returns a non-zero value if all entries
+    on the off-diagonal of *mat* are zero, and otherwise returns zero.
 
 .. function:: int fmpz_mat_is_nonnegative(const fmpz_mat_t mat)
 
@@ -32,6 +37,10 @@ Comparison
 
     Sets each entry in *dest* to zero or one according to whether
     or not the corresponding entry in *src* is zero.
+
+.. function:: slong fmpz_mat_count_nonzero(const fmpz_mat_t mat)
+
+    Returns the number of non-zero entries in *mat*.
 
 
 Arithmetic

--- a/fmpz_mat_extras.h
+++ b/fmpz_mat_extras.h
@@ -35,6 +35,16 @@ extern "C" {
 
 void fmpz_mat_transitive_closure(fmpz_mat_t dest, const fmpz_mat_t src);
 
+void fmpz_mat_entrywise_nilpotence_degree(fmpz_mat_t dest, const fmpz_mat_t src);
+
+void fmpz_mat_entrywise_not_is_zero(fmpz_mat_t dest, const fmpz_mat_t src);
+
+int fmpz_mat_is_hollow(const fmpz_mat_t mat);
+
+int fmpz_mat_is_nonnegative(const fmpz_mat_t mat);
+
+int fmpz_mat_is_lower_triangular(const fmpz_mat_t mat);
+
 #ifdef __cplusplus
 }
 #endif

--- a/fmpz_mat_extras.h
+++ b/fmpz_mat_extras.h
@@ -33,15 +33,19 @@
 extern "C" {
 #endif
 
-/* Comparison */
+/* Convenience functions related to sparsity structure */
 
 int fmpz_mat_is_hollow(const fmpz_mat_t mat);
+
+int fmpz_mat_is_diagonal(const fmpz_mat_t mat);
 
 int fmpz_mat_is_nonnegative(const fmpz_mat_t mat);
 
 int fmpz_mat_is_lower_triangular(const fmpz_mat_t mat);
 
 void fmpz_mat_entrywise_not_is_zero(fmpz_mat_t dest, const fmpz_mat_t src);
+
+slong fmpz_mat_count_nonzero(const fmpz_mat_t mat);
 
 /* Arithmetic */
 

--- a/fmpz_mat_extras.h
+++ b/fmpz_mat_extras.h
@@ -33,17 +33,27 @@
 extern "C" {
 #endif
 
-void fmpz_mat_transitive_closure(fmpz_mat_t dest, const fmpz_mat_t src);
-
-void fmpz_mat_entrywise_nilpotence_degree(fmpz_mat_t dest, const fmpz_mat_t src);
-
-void fmpz_mat_entrywise_not_is_zero(fmpz_mat_t dest, const fmpz_mat_t src);
+/* Comparison */
 
 int fmpz_mat_is_hollow(const fmpz_mat_t mat);
 
 int fmpz_mat_is_nonnegative(const fmpz_mat_t mat);
 
 int fmpz_mat_is_lower_triangular(const fmpz_mat_t mat);
+
+void fmpz_mat_entrywise_not_is_zero(fmpz_mat_t dest, const fmpz_mat_t src);
+
+/* Arithmetic */
+
+void fmpz_mat_add_ui_entrywise(fmpz_mat_t B, const fmpz_mat_t A, ulong x);
+
+void fmpz_mat_sub_ui_entrywise(fmpz_mat_t B, const fmpz_mat_t A, ulong x);
+
+/* Graph theory */
+
+void fmpz_mat_transitive_closure(fmpz_mat_t B, const fmpz_mat_t A);
+
+void fmpz_mat_unweighted_all_pairs_longest_walk(fmpz_mat_t B, const fmpz_mat_t A);
 
 #ifdef __cplusplus
 }

--- a/fmpz_mat_extras/add_ui_entrywise.c
+++ b/fmpz_mat_extras/add_ui_entrywise.c
@@ -1,0 +1,40 @@
+/*=============================================================================
+
+    This file is part of FLINT.
+
+    FLINT is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    FLINT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FLINT; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2016 Arb authors
+
+******************************************************************************/
+
+#include "fmpz_mat_extras.h"
+
+void
+fmpz_mat_add_ui_entrywise(fmpz_mat_t B, const fmpz_mat_t A, ulong x)
+{
+    slong i, j;
+    for (i = 0; i < fmpz_mat_nrows(A); i++)
+    {
+        for (j = 0; j < fmpz_mat_ncols(A); j++)
+        {
+            fmpz_add_ui(fmpz_mat_entry(B, i, j),
+                        fmpz_mat_entry(A, i, j), x);
+        }
+    }
+}

--- a/fmpz_mat_extras/count_nonzero.c
+++ b/fmpz_mat_extras/count_nonzero.c
@@ -1,0 +1,42 @@
+/*=============================================================================
+
+    This file is part of FLINT.
+
+    FLINT is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    FLINT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FLINT; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2016 Arb authors
+
+******************************************************************************/
+
+#include "fmpz_mat_extras.h"
+
+slong
+fmpz_mat_count_nonzero(const fmpz_mat_t mat)
+{
+    slong i, j, total;
+
+    if (fmpz_mat_is_empty(mat))
+        return 0;
+
+    for (total = 0, i = 0; i < fmpz_mat_nrows(mat); i++)
+        for (j = 0; j < fmpz_mat_ncols(mat); j++)
+            if (!fmpz_is_zero(fmpz_mat_entry(mat, i, j)))
+                total++;
+    
+    return total;
+}

--- a/fmpz_mat_extras/entrywise_nilpotence_degree.c
+++ b/fmpz_mat_extras/entrywise_nilpotence_degree.c
@@ -1,0 +1,554 @@
+/*=============================================================================
+
+    This file is part of ARB.
+
+    ARB is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    ARB is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with ARB; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2016 Arb authors
+
+******************************************************************************/
+
+#include "fmpz_mat_extras.h"
+
+
+/* fixed-capacity stack of fixed-precision signed flint integers */
+typedef struct
+{
+    slong *data;
+    slong capacity;
+    slong size;
+} si_stack_struct;
+typedef si_stack_struct si_stack_t[1];
+
+static void
+si_stack_init(si_stack_t S, slong capacity)
+{
+    S->data = flint_malloc(capacity * sizeof(slong));
+    S->capacity = capacity;
+    S->size = 0;
+}
+
+static void
+si_stack_clear(si_stack_t S)
+{
+    flint_free(S->data);
+}
+
+static void
+si_stack_push(si_stack_t S, slong x)
+{
+    if (S->size >= S->capacity) abort(); /* assert */
+    S->data[S->size++] = x;
+}
+
+static slong
+si_stack_pop(si_stack_t S)
+{
+    slong x;
+    if (S->size <= 0) abort(); /* assert */
+    x = S->data[S->size - 1];
+    S->size--;
+    return x;
+}
+
+
+/* struct for Tarjan's strongly connected components algorithm */
+typedef struct
+{
+    slong *_index;
+    slong *_lowlink;
+    int *_onstack;
+    si_stack_t _S;
+    slong _nsccs;
+    slong _dim;
+    slong _idx;
+} tarjan_struct;
+typedef tarjan_struct tarjan_t[1];
+
+static const slong tarjan_UNDEFINED = -1;
+
+static slong *
+tarjan_index(tarjan_t t, slong i)
+{
+    return t->_index + i;
+}
+
+static slong *
+tarjan_lowlink(tarjan_t t, slong i)
+{
+    return t->_lowlink + i;
+}
+
+static int
+tarjan_onstack(tarjan_t t, slong i)
+{
+    return t->_onstack[i];
+}
+
+static void
+tarjan_push(tarjan_t t, slong v)
+{
+    si_stack_push(t->_S, v);
+    t->_onstack[v] = 1;
+}
+
+static slong
+tarjan_pop(tarjan_t t)
+{
+    slong v;
+    v = si_stack_pop(t->_S);
+    t->_onstack[v] = 0;
+    return v;
+}
+
+static slong
+tarjan_next_scc(tarjan_t t)
+{
+    return t->_nsccs++;
+}
+
+static slong
+tarjan_next_idx(tarjan_t t)
+{
+    return t->_idx++;
+}
+
+static void
+tarjan_init(tarjan_t t, slong dim)
+{
+    slong i;
+    t->_index = flint_calloc(dim, sizeof(slong));
+    t->_lowlink = flint_calloc(dim, sizeof(slong));
+    t->_onstack = flint_calloc(dim, sizeof(int));
+    si_stack_init(t->_S, dim);
+    t->_dim = dim;
+    t->_nsccs = 0;
+    t->_idx = 0;
+    for (i = 0; i < dim; i++)
+    {
+        t->_index[i] = tarjan_UNDEFINED;
+    }
+}
+
+static void
+tarjan_clear(tarjan_t t)
+{
+    flint_free(t->_index);
+    flint_free(t->_lowlink);
+    flint_free(t->_onstack);
+    si_stack_clear(t->_S);
+}
+
+static void
+tarjan_strongconnect(slong *sccs, tarjan_t t, const fmpz_mat_t A, slong v)
+{
+    slong idx, w, scc;
+
+    idx = tarjan_next_idx(t);
+    *tarjan_index(t, v) = idx;
+    *tarjan_lowlink(t, v) = idx;
+    tarjan_push(t, v);
+    for (w = 0; w < t->_dim; w++)
+    {
+        if (!fmpz_is_zero(fmpz_mat_entry(A, v, w)))
+        {
+            if (*tarjan_index(t, w) == tarjan_UNDEFINED)
+            {
+                tarjan_strongconnect(sccs, t, A, w);
+                *tarjan_lowlink(t, v) = FLINT_MIN(
+                        *tarjan_lowlink(t, v), *tarjan_lowlink(t, w));
+            }
+            else if (tarjan_onstack(t, w))
+            {
+                *tarjan_lowlink(t, v) = FLINT_MIN(
+                        *tarjan_lowlink(t, v), *tarjan_index(t, w));
+            }
+        }
+    }
+    if (*tarjan_lowlink(t, v) == *tarjan_index(t, v))
+    {
+        scc = tarjan_next_scc(t);
+        while (w != v)
+        {
+            w = tarjan_pop(t);
+            if (sccs[w] != tarjan_UNDEFINED) abort(); /* assert */
+            sccs[w] = scc;
+        }
+    }
+}
+
+
+/* Tarjan's strongly connected components algorithm */
+void
+_fmpz_mat_get_sccs(slong *sccs, const fmpz_mat_t A)
+{
+    slong v, dim;
+    tarjan_t t;
+
+    dim = fmpz_mat_nrows(A);
+
+    if (dim != fmpz_mat_ncols(A))
+    {
+        flint_printf("_fmpz_mat_get_sccs: a square matrix is required!\n");
+        abort();
+    }
+
+    tarjan_init(t, dim);
+
+    for (v = 0; v < dim; v++)
+    {
+        sccs[v] = tarjan_UNDEFINED;
+    }
+    for (v = 0; v < dim; v++)
+    {
+        if (*tarjan_index(t, v) == tarjan_UNDEFINED)
+        {
+            tarjan_strongconnect(sccs, t, A, v);
+        }
+    }
+
+    tarjan_clear(t);
+}
+
+
+/*
+ * Condensation of a matrix.
+ * This is the directed acyclic graph of strongly connected components.
+ */
+typedef struct
+{
+    slong n; /* number of vertices in the original graph */
+    slong k; /* number of strongly connnected components (sccs) */
+    fmpz_mat_t C; /* adjacency matrix of the sccs in the condensation */
+    slong *partition; /* maps the vertex index to the scc index */
+} condensation_struct;
+
+typedef condensation_struct condensation_t[1];
+
+void
+condensation_fprint(FILE * file, condensation_t c)
+{
+    slong i;
+    flint_fprintf(file, "number of vertices: %wd\n", c->n);
+    flint_fprintf(file, "number of SCCs: %wd\n", c->k);
+    flint_fprintf(file, "adjacency matrix of SCCs:\n");
+    fmpz_mat_fprint_pretty(file, c->C);
+    flint_fprintf(file, "\n");
+    flint_fprintf(file, "partition of vertices:\n");
+    for (i = 0; i < c->n; i++)
+    {
+        flint_fprintf(file, "%wd : %wd\n", i, c->partition[i]);
+    }
+}
+
+void
+condensation_init(condensation_t c, const fmpz_mat_t A)
+{
+    slong i, j, u, v;
+
+    c->n = fmpz_mat_nrows(A);
+    if (c->n != fmpz_mat_ncols(A))
+    {
+        flint_printf("condensation_init: a square matrix is required!\n");
+        abort();
+    }
+
+    c->partition = flint_malloc(c->n * sizeof(slong));
+
+    _fmpz_mat_get_sccs(c->partition, A);
+
+    /* count the strongly connected components */
+    c->k = 0;
+    for (i = 0; i < c->n; i++)
+    {
+        u = c->partition[i];
+        c->k = FLINT_MAX(c->k, u + 1);
+    }
+
+    /*
+     * Compute the adjacency matrix of the condensation.
+     * This should be strict lower triangular, so that visiting the
+     * vertices in increasing order corresponds to a postorder traversal.
+     */
+    fmpz_mat_init(c->C, c->k, c->k);
+    fmpz_mat_zero(c->C);
+    for (i = 0; i < c->n; i++)
+    {
+        for (j = 0; j < c->n; j++)
+        {
+            if (!fmpz_is_zero(fmpz_mat_entry(A, i, j)))
+            {
+                u = c->partition[i];
+                v = c->partition[j];
+                if (u != v)
+                {
+                    fmpz_one(fmpz_mat_entry(c->C, u, v));
+                }
+            }
+        }
+    }
+
+    if (!fmpz_mat_is_lower_triangular(c->C) ||
+        !fmpz_mat_is_hollow(c->C))
+    {
+        flint_printf("condensation_init: unexpected matrix structure\n");
+        fmpz_mat_print_pretty(c->C);
+        abort();
+    }
+}
+
+void
+condensation_clear(condensation_t c)
+{
+    fmpz_mat_clear(c->C);
+    flint_free(c->partition);
+}
+
+
+
+typedef struct
+{
+    condensation_t con;
+    fmpz_mat_t T; /* transitive closure of condensation */
+    fmpz_mat_t P; /* is there a cycle in any component on a path from u to v */
+    fmpz_mat_t Q; /* longest path, if any, from u to v */
+    int *scc_has_cycle;
+} connectivity_struct;
+typedef connectivity_struct connectivity_t[1];
+
+void
+connectivity_fprint(FILE * file, connectivity_t c)
+{
+    slong i;
+    flint_fprintf(file, "begin condensation ...\n");
+    condensation_fprint(file, c->con);
+    flint_fprintf(file, "... end condensation\n");
+    flint_fprintf(file, "transitive closure of condensation:\n");
+    fmpz_mat_fprint_pretty(file, c->T);
+    flint_fprintf(file, "a path goes through a cycle-containing SCC:\n");
+    fmpz_mat_fprint_pretty(file, c->P);
+    flint_fprintf(file, "max path length in condensation:\n");
+    fmpz_mat_fprint_pretty(file, c->Q);
+    flint_fprintf(file, "SCC has cycle:\n");
+    for (i = 0; i < c->con->k; i++)
+    {
+        flint_fprintf(file, "%wd : %d\n", i, c->scc_has_cycle[i]);
+    }
+}
+
+void
+connectivity_clear(connectivity_t c)
+{
+    fmpz_mat_clear(c->T);
+    fmpz_mat_clear(c->P);
+    fmpz_mat_clear(c->Q);
+    flint_free(c->scc_has_cycle);
+    condensation_clear(c->con);
+}
+
+void
+_connectivity_init_scc_has_cycle(connectivity_t c, const fmpz_mat_t A)
+{
+    slong n, i, u;
+    slong *scc_size;
+
+    n = fmpz_mat_nrows(A);
+    c->scc_has_cycle = flint_calloc(n, sizeof(int));
+
+    /*
+     * If a vertex of the original graph has a loop,
+     * then the strongly connected component to which it belongs has a cycle.
+     */
+    for (i = 0; i < n; i++)
+    {
+        if (!fmpz_is_zero(fmpz_mat_entry(A, i, i)))
+        {
+            u = c->con->partition[i];
+            c->scc_has_cycle[u] = 1;
+        }
+    }
+
+    /*
+     * If a strongly connected component contains more than one vertex,
+     * then that component has a cycle.
+     */
+    scc_size = flint_calloc(c->con->k, sizeof(slong));
+    for (i = 0; i < n; i++)
+    {
+        u = c->con->partition[i];
+        scc_size[u]++;
+    }
+    for (u = 0; u < c->con->k; u++)
+    {
+        if (scc_size[u] > 1)
+        {
+            c->scc_has_cycle[u] = 1;
+        }
+    }
+    flint_free(scc_size);
+}
+
+void
+connectivity_init(connectivity_t c, const fmpz_mat_t A)
+{
+    slong u, v, w;
+    slong k;
+    slong curr, rest;
+
+    /* compute the condensation */
+    condensation_init(c->con, A);
+    k = c->con->k;
+
+    /* check whether each scc contains a cycle */
+    _connectivity_init_scc_has_cycle(c, A);
+
+    /* compute the transitive closure of the condensation */
+    fmpz_mat_init(c->T, k, k);
+    fmpz_mat_transitive_closure(c->T, c->con->C);
+
+    /*
+     * Is there a walk from u to v that passes through a cycle-containing scc?
+     * Cycles in the components u and v themselves are not considered.
+     * Remember that the condensation is a directed acyclic graph.
+     */
+    fmpz_mat_init(c->P, k, k);
+    fmpz_mat_zero(c->P);
+    for (w = 0; w < k; w++)
+    {
+        if (c->scc_has_cycle[w])
+        {
+            for (u = 0; u < k; u++)
+            {
+                for (v = 0; v < k; v++)
+                {
+                    if (!fmpz_is_zero(fmpz_mat_entry(c->T, u, w)) &&
+                        !fmpz_is_zero(fmpz_mat_entry(c->T, w, v)))
+                    {
+                        fmpz_one(fmpz_mat_entry(c->P, u, v));
+                    }
+                }
+            }
+        }
+    }
+
+    /*
+     * What is the max length path from u to v in the condensation graph?
+     * If u==v or if v is unreachable from u then let this be zero.
+     * Remember that the condensation is a directed acyclic graph,
+     * and that the components are indexed in a post-order traversal.
+     */
+    fmpz_mat_init(c->Q, k, k);
+    fmpz_mat_zero(c->Q);
+    for (u = 0; u < k; u++)
+    {
+        for (w = 0; w < k; w++)
+        {
+            if (!fmpz_is_zero(fmpz_mat_entry(c->con->C, u, w)))
+            {
+                curr = fmpz_get_si(fmpz_mat_entry(c->Q, u, w));
+                fmpz_set_si(
+                        fmpz_mat_entry(c->Q, u, w),
+                        FLINT_MAX(curr, 1));
+                for (v = 0; v < k; v++)
+                {
+                    if (!fmpz_is_zero(fmpz_mat_entry(c->T, w, v)))
+                    {
+                        rest = fmpz_get_si(fmpz_mat_entry(c->Q, w, v));
+                        curr = fmpz_get_si(fmpz_mat_entry(c->Q, u, v));
+                        fmpz_set_si(
+                                fmpz_mat_entry(c->Q, u, v),
+                                FLINT_MAX(curr, rest + 1));
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+void
+connectivity_entrywise_nilpotence_degree(
+        fmpz_t N, connectivity_t c, slong i, slong j)
+{
+    slong u, v;
+    u = c->con->partition[i];
+    v = c->con->partition[j];
+    if (u == v)
+    {
+        if (c->scc_has_cycle[u])
+        {
+            fmpz_set_si(N, -1);
+        }
+        else
+        {
+            fmpz_one(N);
+        }
+    }
+    else if (fmpz_is_zero(fmpz_mat_entry(c->T, u, v)))
+    {
+        fmpz_zero(N);
+    }
+    else if (
+            c->scc_has_cycle[u] ||
+            c->scc_has_cycle[v] ||
+            !fmpz_is_zero(fmpz_mat_entry(c->P, u, v)))
+    {
+        fmpz_set_si(N, -1);
+    }
+    else
+    {
+        fmpz_add_ui(N, fmpz_mat_entry(c->Q, u, v), 1);
+    }
+}
+
+/*
+ * Implemented only for entrywise non-negative square matrices.
+ * The term 'entrywise nilpotence degree' is not standard
+ * and may even be misleading, but it's supposed to mean the following:
+ * For each i,j find the smallest non-negative k
+ * so that (A^N)_{ij} = 0 when N >= k.
+ * If there is no such k then set the entry to -1.
+ * The matrix itself is nilpotent if and only if each entry
+ * of the entrywise nilpotence degree matrix is non-negative.
+ * If the matrix is nilpotent, then its nilpotence degree
+ * is the maximum of the entrywise nilpotence degrees.
+ */
+void
+fmpz_mat_entrywise_nilpotence_degree(fmpz_mat_t dest, const fmpz_mat_t src)
+{
+    slong i, j;
+    connectivity_t c;
+
+    if (!fmpz_mat_is_square(src) || !fmpz_mat_is_nonnegative(src))
+    {
+        flint_printf("fmpz_mat_entrywise_nilpotence_degree: "
+                     "a non-negative square matrix is required!\n");
+        abort();
+    }
+
+    connectivity_init(c, src);
+    for (i = 0; i < c->con->n; i++)
+    {
+        for (j = 0; j < c->con->n; j++)
+        {
+            connectivity_entrywise_nilpotence_degree(
+                    fmpz_mat_entry(dest, i, j), c, i, j);
+        }
+    }
+    connectivity_clear(c);
+}

--- a/fmpz_mat_extras/entrywise_nilpotence_degree.c
+++ b/fmpz_mat_extras/entrywise_nilpotence_degree.c
@@ -32,11 +32,11 @@ typedef struct
     slong *data;
     slong capacity;
     slong size;
-} si_stack_struct;
-typedef si_stack_struct si_stack_t[1];
+} _si_stack_struct;
+typedef _si_stack_struct _si_stack_t[1];
 
 static void
-si_stack_init(si_stack_t S, slong capacity)
+_si_stack_init(_si_stack_t S, slong capacity)
 {
     S->data = flint_malloc(capacity * sizeof(slong));
     S->capacity = capacity;
@@ -44,20 +44,20 @@ si_stack_init(si_stack_t S, slong capacity)
 }
 
 static void
-si_stack_clear(si_stack_t S)
+_si_stack_clear(_si_stack_t S)
 {
     flint_free(S->data);
 }
 
 static void
-si_stack_push(si_stack_t S, slong x)
+_si_stack_push(_si_stack_t S, slong x)
 {
     if (S->size >= S->capacity) abort(); /* assert */
     S->data[S->size++] = x;
 }
 
 static slong
-si_stack_pop(si_stack_t S)
+_si_stack_pop(_si_stack_t S)
 {
     slong x;
     if (S->size <= 0) abort(); /* assert */
@@ -73,120 +73,120 @@ typedef struct
     slong *_index;
     slong *_lowlink;
     int *_onstack;
-    si_stack_t _S;
+    _si_stack_t _S;
     slong _nsccs;
     slong _dim;
     slong _idx;
-} tarjan_struct;
-typedef tarjan_struct tarjan_t[1];
+} _tarjan_struct;
+typedef _tarjan_struct _tarjan_t[1];
 
-static const slong tarjan_UNDEFINED = -1;
+static const slong _tarjan_UNDEFINED = -1;
 
 static slong *
-tarjan_index(tarjan_t t, slong i)
+_tarjan_index(_tarjan_t t, slong i)
 {
     return t->_index + i;
 }
 
 static slong *
-tarjan_lowlink(tarjan_t t, slong i)
+_tarjan_lowlink(_tarjan_t t, slong i)
 {
     return t->_lowlink + i;
 }
 
 static int
-tarjan_onstack(tarjan_t t, slong i)
+_tarjan_onstack(_tarjan_t t, slong i)
 {
     return t->_onstack[i];
 }
 
 static void
-tarjan_push(tarjan_t t, slong v)
+_tarjan_push(_tarjan_t t, slong v)
 {
-    si_stack_push(t->_S, v);
+    _si_stack_push(t->_S, v);
     t->_onstack[v] = 1;
 }
 
 static slong
-tarjan_pop(tarjan_t t)
+_tarjan_pop(_tarjan_t t)
 {
     slong v;
-    v = si_stack_pop(t->_S);
+    v = _si_stack_pop(t->_S);
     t->_onstack[v] = 0;
     return v;
 }
 
 static slong
-tarjan_next_scc(tarjan_t t)
+_tarjan_next_scc(_tarjan_t t)
 {
     return t->_nsccs++;
 }
 
 static slong
-tarjan_next_idx(tarjan_t t)
+_tarjan_next_idx(_tarjan_t t)
 {
     return t->_idx++;
 }
 
 static void
-tarjan_init(tarjan_t t, slong dim)
+_tarjan_init(_tarjan_t t, slong dim)
 {
     slong i;
     t->_index = flint_calloc(dim, sizeof(slong));
     t->_lowlink = flint_calloc(dim, sizeof(slong));
     t->_onstack = flint_calloc(dim, sizeof(int));
-    si_stack_init(t->_S, dim);
+    _si_stack_init(t->_S, dim);
     t->_dim = dim;
     t->_nsccs = 0;
     t->_idx = 0;
     for (i = 0; i < dim; i++)
     {
-        t->_index[i] = tarjan_UNDEFINED;
+        t->_index[i] = _tarjan_UNDEFINED;
     }
 }
 
 static void
-tarjan_clear(tarjan_t t)
+_tarjan_clear(_tarjan_t t)
 {
     flint_free(t->_index);
     flint_free(t->_lowlink);
     flint_free(t->_onstack);
-    si_stack_clear(t->_S);
+    _si_stack_clear(t->_S);
 }
 
 static void
-tarjan_strongconnect(slong *sccs, tarjan_t t, const fmpz_mat_t A, slong v)
+_tarjan_strongconnect(slong *sccs, _tarjan_t t, const fmpz_mat_t A, slong v)
 {
     slong idx, w, scc;
 
-    idx = tarjan_next_idx(t);
-    *tarjan_index(t, v) = idx;
-    *tarjan_lowlink(t, v) = idx;
-    tarjan_push(t, v);
+    idx = _tarjan_next_idx(t);
+    *_tarjan_index(t, v) = idx;
+    *_tarjan_lowlink(t, v) = idx;
+    _tarjan_push(t, v);
     for (w = 0; w < t->_dim; w++)
     {
         if (!fmpz_is_zero(fmpz_mat_entry(A, v, w)))
         {
-            if (*tarjan_index(t, w) == tarjan_UNDEFINED)
+            if (*_tarjan_index(t, w) == _tarjan_UNDEFINED)
             {
-                tarjan_strongconnect(sccs, t, A, w);
-                *tarjan_lowlink(t, v) = FLINT_MIN(
-                        *tarjan_lowlink(t, v), *tarjan_lowlink(t, w));
+                _tarjan_strongconnect(sccs, t, A, w);
+                *_tarjan_lowlink(t, v) = FLINT_MIN(
+                        *_tarjan_lowlink(t, v), *_tarjan_lowlink(t, w));
             }
-            else if (tarjan_onstack(t, w))
+            else if (_tarjan_onstack(t, w))
             {
-                *tarjan_lowlink(t, v) = FLINT_MIN(
-                        *tarjan_lowlink(t, v), *tarjan_index(t, w));
+                *_tarjan_lowlink(t, v) = FLINT_MIN(
+                        *_tarjan_lowlink(t, v), *_tarjan_index(t, w));
             }
         }
     }
-    if (*tarjan_lowlink(t, v) == *tarjan_index(t, v))
+    if (*_tarjan_lowlink(t, v) == *_tarjan_index(t, v))
     {
-        scc = tarjan_next_scc(t);
+        scc = _tarjan_next_scc(t);
         while (w != v)
         {
-            w = tarjan_pop(t);
-            if (sccs[w] != tarjan_UNDEFINED) abort(); /* assert */
+            w = _tarjan_pop(t);
+            if (sccs[w] != _tarjan_UNDEFINED) abort(); /* assert */
             sccs[w] = scc;
         }
     }
@@ -194,11 +194,11 @@ tarjan_strongconnect(slong *sccs, tarjan_t t, const fmpz_mat_t A, slong v)
 
 
 /* Tarjan's strongly connected components algorithm */
-void
+static void
 _fmpz_mat_get_sccs(slong *sccs, const fmpz_mat_t A)
 {
     slong v, dim;
-    tarjan_t t;
+    _tarjan_t t;
 
     dim = fmpz_mat_nrows(A);
 
@@ -208,21 +208,21 @@ _fmpz_mat_get_sccs(slong *sccs, const fmpz_mat_t A)
         abort();
     }
 
-    tarjan_init(t, dim);
+    _tarjan_init(t, dim);
 
     for (v = 0; v < dim; v++)
     {
-        sccs[v] = tarjan_UNDEFINED;
+        sccs[v] = _tarjan_UNDEFINED;
     }
     for (v = 0; v < dim; v++)
     {
-        if (*tarjan_index(t, v) == tarjan_UNDEFINED)
+        if (*_tarjan_index(t, v) == _tarjan_UNDEFINED)
         {
-            tarjan_strongconnect(sccs, t, A, v);
+            _tarjan_strongconnect(sccs, t, A, v);
         }
     }
 
-    tarjan_clear(t);
+    _tarjan_clear(t);
 }
 
 
@@ -236,35 +236,19 @@ typedef struct
     slong k; /* number of strongly connnected components (sccs) */
     fmpz_mat_t C; /* adjacency matrix of the sccs in the condensation */
     slong *partition; /* maps the vertex index to the scc index */
-} condensation_struct;
+} _condensation_struct;
 
-typedef condensation_struct condensation_t[1];
+typedef _condensation_struct _condensation_t[1];
 
-void
-condensation_fprint(FILE * file, condensation_t c)
-{
-    slong i;
-    flint_fprintf(file, "number of vertices: %wd\n", c->n);
-    flint_fprintf(file, "number of SCCs: %wd\n", c->k);
-    flint_fprintf(file, "adjacency matrix of SCCs:\n");
-    fmpz_mat_fprint_pretty(file, c->C);
-    flint_fprintf(file, "\n");
-    flint_fprintf(file, "partition of vertices:\n");
-    for (i = 0; i < c->n; i++)
-    {
-        flint_fprintf(file, "%wd : %wd\n", i, c->partition[i]);
-    }
-}
-
-void
-condensation_init(condensation_t c, const fmpz_mat_t A)
+static void
+_condensation_init(_condensation_t c, const fmpz_mat_t A)
 {
     slong i, j, u, v;
 
     c->n = fmpz_mat_nrows(A);
     if (c->n != fmpz_mat_ncols(A))
     {
-        flint_printf("condensation_init: a square matrix is required!\n");
+        flint_printf("_condensation_init: a square matrix is required!\n");
         abort();
     }
 
@@ -306,14 +290,14 @@ condensation_init(condensation_t c, const fmpz_mat_t A)
     if (!fmpz_mat_is_lower_triangular(c->C) ||
         !fmpz_mat_is_hollow(c->C))
     {
-        flint_printf("condensation_init: unexpected matrix structure\n");
+        flint_printf("_condensation_init: unexpected matrix structure\n");
         fmpz_mat_print_pretty(c->C);
         abort();
     }
 }
 
-void
-condensation_clear(condensation_t c)
+static void
+_condensation_clear(_condensation_t c)
 {
     fmpz_mat_clear(c->C);
     flint_free(c->partition);
@@ -323,46 +307,26 @@ condensation_clear(condensation_t c)
 
 typedef struct
 {
-    condensation_t con;
+    _condensation_t con;
     fmpz_mat_t T; /* transitive closure of condensation */
     fmpz_mat_t P; /* is there a cycle in any component on a path from u to v */
     fmpz_mat_t Q; /* longest path, if any, from u to v */
     int *scc_has_cycle;
-} connectivity_struct;
-typedef connectivity_struct connectivity_t[1];
+} _connectivity_struct;
+typedef _connectivity_struct _connectivity_t[1];
 
-void
-connectivity_fprint(FILE * file, connectivity_t c)
-{
-    slong i;
-    flint_fprintf(file, "begin condensation ...\n");
-    condensation_fprint(file, c->con);
-    flint_fprintf(file, "... end condensation\n");
-    flint_fprintf(file, "transitive closure of condensation:\n");
-    fmpz_mat_fprint_pretty(file, c->T);
-    flint_fprintf(file, "a path goes through a cycle-containing SCC:\n");
-    fmpz_mat_fprint_pretty(file, c->P);
-    flint_fprintf(file, "max path length in condensation:\n");
-    fmpz_mat_fprint_pretty(file, c->Q);
-    flint_fprintf(file, "SCC has cycle:\n");
-    for (i = 0; i < c->con->k; i++)
-    {
-        flint_fprintf(file, "%wd : %d\n", i, c->scc_has_cycle[i]);
-    }
-}
-
-void
-connectivity_clear(connectivity_t c)
+static void
+_connectivity_clear(_connectivity_t c)
 {
     fmpz_mat_clear(c->T);
     fmpz_mat_clear(c->P);
     fmpz_mat_clear(c->Q);
     flint_free(c->scc_has_cycle);
-    condensation_clear(c->con);
+    _condensation_clear(c->con);
 }
 
-void
-_connectivity_init_scc_has_cycle(connectivity_t c, const fmpz_mat_t A)
+static void
+_connectivity_init_scc_has_cycle(_connectivity_t c, const fmpz_mat_t A)
 {
     slong n, i, u;
     slong *scc_size;
@@ -403,15 +367,15 @@ _connectivity_init_scc_has_cycle(connectivity_t c, const fmpz_mat_t A)
     flint_free(scc_size);
 }
 
-void
-connectivity_init(connectivity_t c, const fmpz_mat_t A)
+static void
+_connectivity_init(_connectivity_t c, const fmpz_mat_t A)
 {
     slong u, v, w;
     slong k;
     slong curr, rest;
 
     /* compute the condensation */
-    condensation_init(c->con, A);
+    _condensation_init(c->con, A);
     k = c->con->k;
 
     /* check whether each scc contains a cycle */
@@ -481,9 +445,9 @@ connectivity_init(connectivity_t c, const fmpz_mat_t A)
 }
 
 
-void
-connectivity_entrywise_nilpotence_degree(
-        fmpz_t N, connectivity_t c, slong i, slong j)
+static void
+_connectivity_entrywise_nilpotence_degree(
+        fmpz_t N, _connectivity_t c, slong i, slong j)
 {
     slong u, v;
     u = c->con->partition[i];
@@ -532,7 +496,7 @@ void
 fmpz_mat_entrywise_nilpotence_degree(fmpz_mat_t dest, const fmpz_mat_t src)
 {
     slong i, j;
-    connectivity_t c;
+    _connectivity_t c;
 
     if (!fmpz_mat_is_square(src) || !fmpz_mat_is_nonnegative(src))
     {
@@ -541,14 +505,14 @@ fmpz_mat_entrywise_nilpotence_degree(fmpz_mat_t dest, const fmpz_mat_t src)
         abort();
     }
 
-    connectivity_init(c, src);
+    _connectivity_init(c, src);
     for (i = 0; i < c->con->n; i++)
     {
         for (j = 0; j < c->con->n; j++)
         {
-            connectivity_entrywise_nilpotence_degree(
+            _connectivity_entrywise_nilpotence_degree(
                     fmpz_mat_entry(dest, i, j), c, i, j);
         }
     }
-    connectivity_clear(c);
+    _connectivity_clear(c);
 }

--- a/fmpz_mat_extras/entrywise_not_is_zero.c
+++ b/fmpz_mat_extras/entrywise_not_is_zero.c
@@ -1,0 +1,46 @@
+/*=============================================================================
+
+    This file is part of FLINT.
+
+    FLINT is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    FLINT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FLINT; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2016 Arb authors
+
+******************************************************************************/
+
+#include "fmpz_mat_extras.h"
+
+void
+fmpz_mat_entrywise_not_is_zero(fmpz_mat_t dest, const fmpz_mat_t src)
+{
+    slong i, j;
+    for (i = 0; i < fmpz_mat_nrows(src); i++)
+    {
+        for (j = 0; j < fmpz_mat_ncols(src); j++)
+        {
+            if (fmpz_is_zero(fmpz_mat_entry(src, i, j)))
+            {
+                fmpz_zero(fmpz_mat_entry(dest, i, j));
+            }
+            else
+            {
+                fmpz_one(fmpz_mat_entry(dest, i, j));
+            }
+        }
+    }
+}

--- a/fmpz_mat_extras/is_diagonal.c
+++ b/fmpz_mat_extras/is_diagonal.c
@@ -1,0 +1,48 @@
+/*=============================================================================
+
+    This file is part of FLINT.
+
+    FLINT is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    FLINT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FLINT; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2016 Arb authors
+
+******************************************************************************/
+
+#include "fmpz_mat_extras.h"
+
+int
+fmpz_mat_is_diagonal(const fmpz_mat_t mat)
+{
+    slong i, j;
+
+    if (fmpz_mat_is_empty(mat))
+        return 1;
+
+    for (i = 0; i < fmpz_mat_nrows(mat); i++)
+    {
+        for (j = 0; j < fmpz_mat_ncols(mat); j++)
+        {
+            if (i != j && !fmpz_is_zero(fmpz_mat_entry(mat, i, j)))
+            {
+                return 0;
+            }
+        }
+    }
+
+    return 1;
+}

--- a/fmpz_mat_extras/is_hollow.c
+++ b/fmpz_mat_extras/is_hollow.c
@@ -1,0 +1,45 @@
+/*=============================================================================
+
+    This file is part of FLINT.
+
+    FLINT is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    FLINT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FLINT; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2016 Arb authors
+
+******************************************************************************/
+
+#include "fmpz_mat_extras.h"
+
+int
+fmpz_mat_is_hollow(const fmpz_mat_t mat)
+{
+    slong i;
+
+    if (fmpz_mat_is_empty(mat))
+        return 1;
+
+    for (i = 0; i < fmpz_mat_ncols(mat) && i < fmpz_mat_nrows(mat); i++)
+    {
+        if (!fmpz_is_zero(fmpz_mat_entry(mat, i, i)))
+        {
+            return 0;
+        }
+    }
+
+    return 1;
+}

--- a/fmpz_mat_extras/is_lower_triangular.c
+++ b/fmpz_mat_extras/is_lower_triangular.c
@@ -1,0 +1,48 @@
+/*=============================================================================
+
+    This file is part of FLINT.
+
+    FLINT is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    FLINT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FLINT; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2016 Arb authors
+
+******************************************************************************/
+
+#include "fmpz_mat_extras.h"
+
+int
+fmpz_mat_is_lower_triangular(const fmpz_mat_t mat)
+{
+    slong i, j;
+
+    if (fmpz_mat_is_empty(mat))
+        return 1;
+
+    for (j = 0; j < fmpz_mat_ncols(mat); j++)
+    {
+        for (i = 0; i < fmpz_mat_nrows(mat) && i < j; i++)
+        {
+            if (!fmpz_is_zero(fmpz_mat_entry(mat, i, j)))
+            {
+                return 0;
+            }
+        }
+    }
+
+    return 1;
+}

--- a/fmpz_mat_extras/is_nonnegative.c
+++ b/fmpz_mat_extras/is_nonnegative.c
@@ -1,0 +1,48 @@
+/*=============================================================================
+
+    This file is part of FLINT.
+
+    FLINT is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    FLINT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FLINT; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2016 Arb authors
+
+******************************************************************************/
+
+#include "fmpz_mat_extras.h"
+
+int
+fmpz_mat_is_nonnegative(const fmpz_mat_t mat)
+{
+    slong i, j;
+
+    if (fmpz_mat_is_empty(mat))
+        return 1;
+
+    for (i = 0; i < fmpz_mat_nrows(mat); i++)
+    {
+        for (j = 0; j < fmpz_mat_ncols(mat); j++)
+        {
+            if (fmpz_sgn(fmpz_mat_entry(mat, i, j)) < 0)
+            {
+                return 0;
+            }
+        }
+    }
+
+    return 1;
+}

--- a/fmpz_mat_extras/sub_ui_entrywise.c
+++ b/fmpz_mat_extras/sub_ui_entrywise.c
@@ -1,0 +1,40 @@
+/*=============================================================================
+
+    This file is part of FLINT.
+
+    FLINT is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    FLINT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FLINT; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2016 Arb authors
+
+******************************************************************************/
+
+#include "fmpz_mat_extras.h"
+
+void
+fmpz_mat_sub_ui_entrywise(fmpz_mat_t B, const fmpz_mat_t A, ulong x)
+{
+    slong i, j;
+    for (i = 0; i < fmpz_mat_nrows(A); i++)
+    {
+        for (j = 0; j < fmpz_mat_ncols(A); j++)
+        {
+            fmpz_sub_ui(fmpz_mat_entry(B, i, j),
+                        fmpz_mat_entry(A, i, j), x);
+        }
+    }
+}

--- a/fmpz_mat_extras/test/t-entrywise_nilpotence_degree.c
+++ b/fmpz_mat_extras/test/t-entrywise_nilpotence_degree.c
@@ -55,7 +55,6 @@ _nilpotence_degree_is_superficially_ok_entrywise(const fmpz_mat_t A)
     return 1;
 }
 
-/* todo: unfinished after here ... just copied from transitive closure ... */
 
 /* permute rows and columns of a square matrix */
 void

--- a/fmpz_mat_extras/test/t-unweighted_all_pairs_longest_walk.c
+++ b/fmpz_mat_extras/test/t-unweighted_all_pairs_longest_walk.c
@@ -100,7 +100,7 @@ _fmpz_mat_permute(fmpz_mat_t B, const fmpz_mat_t A, const slong *perm)
 
 /* this is not efficient */
 void
-_brute_force_entrywise_nilpotence_degree(fmpz_mat_t B, const fmpz_mat_t A)
+_brute_force_unweighted_all_pairs_longest_walk(fmpz_mat_t B, const fmpz_mat_t A)
 {
     slong n, i, j, k;
     fmpz_mat_t S, curr, accum;
@@ -148,6 +148,8 @@ _brute_force_entrywise_nilpotence_degree(fmpz_mat_t B, const fmpz_mat_t A)
         }
     }
     fmpz_mat_clear(accum);
+
+    fmpz_mat_sub_ui_entrywise(B, B, 1);
 }
 
 
@@ -156,7 +158,7 @@ int main()
     slong iter;
     flint_rand_t state;
 
-    flint_printf("entrywise_nilpotence_degree....");
+    flint_printf("unweighted_all_pairs_longest_walk....");
     fflush(stdout);
 
     flint_randinit(state);
@@ -176,7 +178,8 @@ int main()
         fmpz_mat_randtest(A, state, n_randint(state, 20) + 1);
         fmpz_mat_entrywise_not_is_zero(A, A);
 
-        fmpz_mat_entrywise_nilpotence_degree(B, A);
+        fmpz_mat_unweighted_all_pairs_longest_walk(B, A);
+        fmpz_mat_add_ui_entrywise(B, B, 1);
 
         if (!_nilpotence_degree_is_superficially_ok_entrywise(B))
         {
@@ -189,7 +192,8 @@ int main()
         /* aliasing */
         {
             fmpz_mat_set(C, A);
-            fmpz_mat_entrywise_nilpotence_degree(C, C);
+            fmpz_mat_unweighted_all_pairs_longest_walk(C, C);
+            fmpz_mat_add_ui_entrywise(C, C, 1);
             if (!fmpz_mat_equal(B, C))
             {
                 flint_printf("FAIL (aliasing)\n");
@@ -240,24 +244,25 @@ int main()
             fmpz_mat_clear(V);
         }
 
-        /* test commutativity of permutation with entrywise nilpotence */
+        /* test commutativity of all pairs longest path with permutation */
         {
             slong *perm;
             perm = flint_malloc(m * sizeof(slong));
             _perm_randtest(perm, m, state);
 
-            /* C is the entrywise nilpotence of the permutation of A */
+            /* C is the 'entrywise nilpotence' of the permutation of A */
             fmpz_mat_randtest(C, state, n_randint(state, 20) + 1);
             _fmpz_mat_permute(C, A, perm);
-            fmpz_mat_entrywise_nilpotence_degree(C, C);
+            fmpz_mat_unweighted_all_pairs_longest_walk(C, C);
+            fmpz_mat_add_ui_entrywise(C, C, 1);
 
-            /* D is the permutation of the entrywise nilpotence of A */
+            /* D is the permutation of the 'entrywise nilpotence' of A */
             fmpz_mat_randtest(D, state, n_randint(state, 20) + 1);
             _fmpz_mat_permute(D, B, perm);
 
             if (!fmpz_mat_equal(C, D))
             {
-                flint_printf("FAIL (commutativity with permutation)\n");
+                flint_printf("FAIL (permutation)\n");
                 fmpz_mat_print_pretty(A); flint_printf("\n\n");
                 fmpz_mat_print_pretty(B); flint_printf("\n\n");
                 fmpz_mat_print_pretty(C); flint_printf("\n\n");
@@ -288,8 +293,11 @@ int main()
         fmpz_mat_randtest(A, state, n_randint(state, 20) + 1);
         fmpz_mat_entrywise_not_is_zero(A, A);
 
-        fmpz_mat_entrywise_nilpotence_degree(B, A);
-        _brute_force_entrywise_nilpotence_degree(C, A);
+        fmpz_mat_unweighted_all_pairs_longest_walk(B, A);
+        fmpz_mat_add_ui_entrywise(B, B, 1);
+
+        _brute_force_unweighted_all_pairs_longest_walk(C, A);
+        fmpz_mat_add_ui_entrywise(C, C, 1);
 
         if (!fmpz_mat_equal(B, C))
         {
@@ -314,7 +322,8 @@ int main()
             fmpz_mat_init(A, m, m);
             fmpz_mat_init(B, m, m);
             _fmpz_mat_directed_path_adjacency(A);
-            fmpz_mat_entrywise_nilpotence_degree(B, A);
+            fmpz_mat_unweighted_all_pairs_longest_walk(B, A);
+            fmpz_mat_add_ui_entrywise(B, B, 1);
 
             for (i = 0; i < m; i++)
             {
@@ -345,7 +354,8 @@ int main()
             fmpz_mat_init(A, m, m);
             fmpz_mat_init(B, m, m);
             _fmpz_mat_directed_cycle_adjacency(A);
-            fmpz_mat_entrywise_nilpotence_degree(B, A);
+            fmpz_mat_unweighted_all_pairs_longest_walk(B, A);
+            fmpz_mat_add_ui_entrywise(B, B, 1);
 
             for (i = 0; i < m; i++)
             {

--- a/fmpz_mat_extras/unweighted_all_pairs_longest_walk.c
+++ b/fmpz_mat_extras/unweighted_all_pairs_longest_walk.c
@@ -480,39 +480,29 @@ _connectivity_entrywise_nilpotence_degree(
     }
 }
 
-/*
- * Implemented only for entrywise non-negative square matrices.
- * The term 'entrywise nilpotence degree' is not standard
- * and may even be misleading, but it's supposed to mean the following:
- * For each i,j find the smallest non-negative k
- * so that (A^N)_{ij} = 0 when N >= k.
- * If there is no such k then set the entry to -1.
- * The matrix itself is nilpotent if and only if each entry
- * of the entrywise nilpotence degree matrix is non-negative.
- * If the matrix is nilpotent, then its nilpotence degree
- * is the maximum of the entrywise nilpotence degrees.
- */
 void
-fmpz_mat_entrywise_nilpotence_degree(fmpz_mat_t dest, const fmpz_mat_t src)
+fmpz_mat_unweighted_all_pairs_longest_walk(fmpz_mat_t B, const fmpz_mat_t A)
 {
     slong i, j;
     _connectivity_t c;
 
-    if (!fmpz_mat_is_square(src) || !fmpz_mat_is_nonnegative(src))
+    if (!fmpz_mat_is_square(A) || !fmpz_mat_is_nonnegative(A))
     {
-        flint_printf("fmpz_mat_entrywise_nilpotence_degree: "
+        flint_printf("fmpz_mat_unweighted_all_pairs_longest_walk: "
                      "a non-negative square matrix is required!\n");
         abort();
     }
 
-    _connectivity_init(c, src);
+    _connectivity_init(c, A);
     for (i = 0; i < c->con->n; i++)
     {
         for (j = 0; j < c->con->n; j++)
         {
             _connectivity_entrywise_nilpotence_degree(
-                    fmpz_mat_entry(dest, i, j), c, i, j);
+                    fmpz_mat_entry(B, i, j), c, i, j);
         }
     }
     _connectivity_clear(c);
+
+    fmpz_mat_sub_ui_entrywise(B, B, 1);
 }


### PR DESCRIPTION
Avoid adding unnecessary matrix power truncation terms to functions of nilpotent or "partially nilpotent" matrices. An example (maybe unnecessarily contrived) is the nilpotent matrix
```
A =
[0 2^-100 0]
[0 0 2^100]
[0 0 0]
```
for which the matrix exponential with `prec=32` used to have large error bounds
```
[1 +/- 0, 7.88860905221012e-31 +/- 2.0842e+13, 0.5 +/- 1.321e+43]
[0 +/- 0, 1 +/- 0, 1.26765060022823e+30 +/- 2.0842e+13]
[0 +/- 0, 0 +/- 0, 1 +/- 0]
```
but which is now recognized as having no error:
```
[1 +/- 0, 7.88860905221012e-31 +/- 0, 0.5 +/- 0]
[0 +/- 0, 1 +/- 0, 1.26765060022823e+30 +/- 0]
[0 +/- 0, 0 +/- 0, 1 +/- 0]
```

The PR includes a test, but no new docs yet. It also includes some new utility functions in `fmpz_mat_extras`.