### PR TITLE
MAINT: bool_mat entry getter and setter

### DIFF
--- a/bool_mat.h
+++ b/bool_mat.h
@@ -51,14 +51,19 @@ bool_mat_struct;
 
 typedef bool_mat_struct bool_mat_t[1];
 
-#define bool_mat_entry(mat,i,j) ((mat)->rows[(i)] + (j))
 #define bool_mat_nrows(mat) ((mat)->r)
 #define bool_mat_ncols(mat) ((mat)->c)
 
-BOOL_MAT_INLINE int *
-bool_mat_entry_ptr(bool_mat_t mat, slong i, slong j)
+BOOL_MAT_INLINE int
+bool_mat_get_entry(const bool_mat_t mat, slong i, slong j)
 {
-    return bool_mat_entry(mat, i, j);
+    return mat->rows[i][j];
+}
+
+BOOL_MAT_INLINE void
+bool_mat_set_entry(bool_mat_t mat, slong i, slong j, int value)
+{
+    mat->rows[i][j] = value;
 }
 
 /* Memory management */

--- a/bool_mat/add.c
+++ b/bool_mat/add.c
@@ -35,6 +35,6 @@ bool_mat_add(bool_mat_t res, const bool_mat_t mat1, const bool_mat_t mat2)
 
     for (i = 0; i < bool_mat_nrows(mat1); i++)
         for (j = 0; j < bool_mat_ncols(mat1); j++)
-            *bool_mat_entry(res, i, j) = (*bool_mat_entry(mat1, i, j) |
-                                          *bool_mat_entry(mat2, i, j));
+            bool_mat_set_entry(res, i, j, (bool_mat_get_entry(mat1, i, j) |
+                                           bool_mat_get_entry(mat2, i, j)));
 }

--- a/bool_mat/all.c
+++ b/bool_mat/all.c
@@ -35,7 +35,7 @@ bool_mat_all(const bool_mat_t mat)
 
     for (i = 0; i < bool_mat_nrows(mat); i++)
         for (j = 0; j < bool_mat_ncols(mat); j++)
-            if (!*bool_mat_entry(mat, i, j))
+            if (!bool_mat_get_entry(mat, i, j))
                 return 0;
 
     return 1;

--- a/bool_mat/all_pairs_longest_walk.c
+++ b/bool_mat/all_pairs_longest_walk.c
@@ -63,13 +63,13 @@ _condensation_init(_condensation_t c, const bool_mat_t A)
     {
         for (j = 0; j < c->n; j++)
         {
-            if (*bool_mat_entry(A, i, j))
+            if (bool_mat_get_entry(A, i, j))
             {
                 u = c->partition[i];
                 v = c->partition[j];
                 if (u != v)
                 {
-                    *bool_mat_entry(c->C, u, v) = 1;
+                    bool_mat_set_entry(c->C, u, v, 1);
                 }
             }
         }
@@ -129,7 +129,7 @@ _connectivity_init_scc_has_cycle(_connectivity_t c, const bool_mat_t A)
      */
     for (i = 0; i < n; i++)
     {
-        if (*bool_mat_entry(A, i, i))
+        if (bool_mat_get_entry(A, i, i))
         {
             u = c->con->partition[i];
             c->scc_has_cycle[u] = 1;
@@ -189,10 +189,10 @@ _connectivity_init(_connectivity_t c, const bool_mat_t A)
             {
                 for (v = 0; v < k; v++)
                 {
-                    if (*bool_mat_entry(c->T, u, w) &&
-                        *bool_mat_entry(c->T, w, v))
+                    if (bool_mat_get_entry(c->T, u, w) &&
+                        bool_mat_get_entry(c->T, w, v))
                     {
-                        *bool_mat_entry(c->P, u, v) = 1;
+                        bool_mat_set_entry(c->P, u, v, 1);
                     }
                 }
             }
@@ -211,7 +211,7 @@ _connectivity_init(_connectivity_t c, const bool_mat_t A)
     {
         for (w = 0; w < k; w++)
         {
-            if (*bool_mat_entry(c->con->C, u, w))
+            if (bool_mat_get_entry(c->con->C, u, w))
             {
                 curr = fmpz_get_si(fmpz_mat_entry(c->Q, u, w));
                 fmpz_set_si(
@@ -219,7 +219,7 @@ _connectivity_init(_connectivity_t c, const bool_mat_t A)
                         FLINT_MAX(curr, 1));
                 for (v = 0; v < k; v++)
                 {
-                    if (*bool_mat_entry(c->T, w, v))
+                    if (bool_mat_get_entry(c->T, w, v))
                     {
                         rest = fmpz_get_si(fmpz_mat_entry(c->Q, w, v));
                         curr = fmpz_get_si(fmpz_mat_entry(c->Q, u, v));
@@ -252,14 +252,14 @@ _connectivity_entrywise_nilpotence_degree(
             fmpz_one(N);
         }
     }
-    else if (!*bool_mat_entry(c->T, u, v))
+    else if (!bool_mat_get_entry(c->T, u, v))
     {
         fmpz_zero(N);
     }
     else if (
             c->scc_has_cycle[u] ||
             c->scc_has_cycle[v] ||
-            *bool_mat_entry(c->P, u, v))
+            bool_mat_get_entry(c->P, u, v))
     {
         fmpz_set_si(N, -1);
     }
@@ -288,7 +288,7 @@ bool_mat_all_pairs_longest_walk(fmpz_mat_t B, const bool_mat_t A)
 
     if (n == 1)
     {
-        if (*bool_mat_entry(A, 0, 0))
+        if (bool_mat_get_entry(A, 0, 0))
         {
             fmpz_set_si(fmpz_mat_entry(B, 0, 0), -2);
             return -2;

--- a/bool_mat/any.c
+++ b/bool_mat/any.c
@@ -35,7 +35,7 @@ bool_mat_any(const bool_mat_t mat)
 
     for (i = 0; i < bool_mat_nrows(mat); i++)
         for (j = 0; j < bool_mat_ncols(mat); j++)
-            if (*bool_mat_entry(mat, i, j))
+            if (bool_mat_get_entry(mat, i, j))
                 return 1;
 
     return 0;

--- a/bool_mat/complement.c
+++ b/bool_mat/complement.c
@@ -35,5 +35,5 @@ bool_mat_complement(bool_mat_t dest, const bool_mat_t src)
 
     for (i = 0; i < bool_mat_nrows(src); i++)
         for (j = 0; j < bool_mat_ncols(src); j++)
-            *bool_mat_entry(dest, i, j) = !*bool_mat_entry(src, i, j);
+            bool_mat_set_entry(dest, i, j, !bool_mat_get_entry(src, i, j));
 }

--- a/bool_mat/directed_cycle.c
+++ b/bool_mat/directed_cycle.c
@@ -38,5 +38,5 @@ bool_mat_directed_cycle(bool_mat_t mat)
         return;
 
     bool_mat_directed_path(mat);
-    *bool_mat_entry(mat, bool_mat_nrows(mat) - 1, 0) = 1;
+    bool_mat_set_entry(mat, bool_mat_nrows(mat) - 1, 0, 1);
 }

--- a/bool_mat/directed_path.c
+++ b/bool_mat/directed_path.c
@@ -42,6 +42,6 @@ bool_mat_directed_path(bool_mat_t mat)
     bool_mat_zero(mat);
     for (i = 0; i < bool_mat_nrows(mat) - 1; i++)
     {
-        *bool_mat_entry(mat, i, i+1) = 1;
+        bool_mat_set_entry(mat, i, i+1, 1);
     }
 }

--- a/bool_mat/equal.c
+++ b/bool_mat/equal.c
@@ -36,8 +36,11 @@ bool_mat_equal(const bool_mat_t mat1, const bool_mat_t mat2)
 
     for (i = 0; i < bool_mat_nrows(mat1); i++)
         for (j = 0; j < bool_mat_ncols(mat1); j++)
-            if (*bool_mat_entry(mat1, i, j) != *bool_mat_entry(mat2, i, j))
+            if (bool_mat_get_entry(mat1, i, j) !=
+                bool_mat_get_entry(mat2, i, j))
+            {
                 return 0;
+            }
 
     return 1;
 }

--- a/bool_mat/fprint.c
+++ b/bool_mat/fprint.c
@@ -36,7 +36,7 @@ bool_mat_fprint(FILE * file, const bool_mat_t mat)
 
         for (j = 0; j < bool_mat_ncols(mat); j++)
         {
-            flint_fprintf(file, "%d", *bool_mat_entry(mat, i, j));
+            flint_fprintf(file, "%d", bool_mat_get_entry(mat, i, j));
 
             if (j < bool_mat_ncols(mat) - 1)
                 flint_fprintf(file, ", ");

--- a/bool_mat/get_strongly_connected_components.c
+++ b/bool_mat/get_strongly_connected_components.c
@@ -166,7 +166,7 @@ _tarjan_strongconnect(slong *sccs, _tarjan_t t, const bool_mat_t A, slong v)
     _tarjan_push(t, v);
     for (w = 0; w < t->dim; w++)
     {
-        if (*bool_mat_entry(A, v, w))
+        if (bool_mat_get_entry(A, v, w))
         {
             if (*_tarjan_index(t, w) == _tarjan_UNDEFINED)
             {

--- a/bool_mat/is_diagonal.c
+++ b/bool_mat/is_diagonal.c
@@ -35,7 +35,7 @@ bool_mat_is_diagonal(const bool_mat_t mat)
 
     for (i = 0; i < bool_mat_nrows(mat); i++)
         for (j = 0; j < bool_mat_ncols(mat); j++)
-            if (i != j && *bool_mat_entry(mat, i, j))
+            if (i != j && bool_mat_get_entry(mat, i, j))
                 return 0;
 
     return 1;

--- a/bool_mat/is_lower_triangular.c
+++ b/bool_mat/is_lower_triangular.c
@@ -35,7 +35,7 @@ bool_mat_is_lower_triangular(const bool_mat_t mat)
 
     for (j = 0; j < bool_mat_ncols(mat); j++)
         for (i = 0; i < bool_mat_nrows(mat) && i < j; i++)
-            if (*bool_mat_entry(mat, i, j))
+            if (bool_mat_get_entry(mat, i, j))
                 return 0;
 
     return 1;

--- a/bool_mat/is_nilpotent.c
+++ b/bool_mat/is_nilpotent.c
@@ -62,7 +62,7 @@ _cycle_detection_visit(_cycle_detection_s *s, const bool_mat_t A, slong n)
         slong m;
         s->u[n] = 1;
         for (m = 0; m < s->size; m++)
-            if (*bool_mat_entry(A, n, m))
+            if (bool_mat_get_entry(A, n, m))
                 if (_cycle_detection_visit(s, A, m))
                     return 1;
         s->v[n] = 1;
@@ -89,7 +89,7 @@ bool_mat_is_nilpotent(const bool_mat_t A)
 
     if (n == 1)
     {
-        return !*bool_mat_entry(A, 0, 0);
+        return !bool_mat_get_entry(A, 0, 0);
     }
     else
     {

--- a/bool_mat/is_transitive.c
+++ b/bool_mat/is_transitive.c
@@ -44,9 +44,9 @@ bool_mat_is_transitive(const bool_mat_t mat)
     for (i = 0; i < n; i++)
         for (j = 0; j < n; j++)
             for (k = 0; k < n; k++)
-                if (*bool_mat_entry(mat, i, j) &&
-                    *bool_mat_entry(mat, j, k) &&
-                    !*bool_mat_entry(mat, i, k))
+                if (bool_mat_get_entry(mat, i, j) &&
+                    bool_mat_get_entry(mat, j, k) &&
+                    !bool_mat_get_entry(mat, i, k))
                 {
                     return 0;
                 }

--- a/bool_mat/mul.c
+++ b/bool_mat/mul.c
@@ -61,13 +61,11 @@ bool_mat_mul(bool_mat_t C, const bool_mat_t A, const bool_mat_t B)
     {
         for (j = 0; j < bc; j++)
         {
-            *bool_mat_entry(C, i, j) = (*bool_mat_entry(A, i, 0) &
-                                        *bool_mat_entry(B, 0, j));
-            for (k = 1; k < br; k++)
-            {
-                *bool_mat_entry(C, i, j) |= (*bool_mat_entry(A, i, k) &
-                                             *bool_mat_entry(B, k, j));
-            }
+            int any = 0;
+            for (k = 0; k < br && !any; k++)
+                any |= (bool_mat_get_entry(A, i, k) &
+                        bool_mat_get_entry(B, k, j));
+            bool_mat_set_entry(C, i, j, any);
         }
     }
 }

--- a/bool_mat/mul_entrywise.c
+++ b/bool_mat/mul_entrywise.c
@@ -41,8 +41,8 @@ bool_mat_mul_entrywise(bool_mat_t C, const bool_mat_t A, const bool_mat_t B)
     {
         for (j = 0; j < bool_mat_ncols(A); j++)
         {
-            *bool_mat_entry(C, i, j) = (*bool_mat_entry(A, i, j) &
-                                        *bool_mat_entry(B, i, j));
+            bool_mat_set_entry(C, i, j, (bool_mat_get_entry(A, i, j) &
+                                         bool_mat_get_entry(B, i, j)));
         }
     }
 }

--- a/bool_mat/nilpotency_degree.c
+++ b/bool_mat/nilpotency_degree.c
@@ -68,7 +68,7 @@ _toposort_visit(_toposort_s *s, const bool_mat_t A, slong n)
         slong m;
         s->u[n] = 1;
         for (m = 0; m < s->size; m++)
-            if (*bool_mat_entry(A, n, m))
+            if (bool_mat_get_entry(A, n, m))
                 if (_toposort_visit(s, A, m))
                     return 1;
         s->v[n] = 1;
@@ -96,7 +96,7 @@ bool_mat_nilpotency_degree(const bool_mat_t A)
 
     if (n == 1)
     {
-        return *bool_mat_entry(A, 0, 0) ? -1 : 1;
+        return bool_mat_get_entry(A, 0, 0) ? -1 : 1;
     }
     else
     {
@@ -138,7 +138,7 @@ bool_mat_nilpotency_degree(const bool_mat_t A)
                 }
                 for (z = 0; z < n; z++)
                 {
-                    if (*bool_mat_entry(A, y, z))
+                    if (bool_mat_get_entry(A, y, z))
                     {
                         fmpz_set_si(fmpz_mat_entry(E, y, z), max_in + 1);
                         max_overall = FLINT_MAX(max_overall, max_in + 1);

--- a/bool_mat/one.c
+++ b/bool_mat/one.c
@@ -32,5 +32,5 @@ bool_mat_one(bool_mat_t mat)
 
     for (i = 0; i < bool_mat_nrows(mat); i++)
         for (j = 0; j < bool_mat_ncols(mat); j++)
-            *bool_mat_entry(mat, i, j) = (i == j);
+            bool_mat_set_entry(mat, i, j, i == j);
 }

--- a/bool_mat/pow_ui.c
+++ b/bool_mat/pow_ui.c
@@ -49,7 +49,7 @@ bool_mat_pow_ui(bool_mat_t B, const bool_mat_t A, ulong exp)
         }
         else if (d == 1)
         {
-            *bool_mat_entry(B, 0, 0) = *bool_mat_entry(A, 0, 0);
+            bool_mat_set_entry(B, 0, 0, bool_mat_get_entry(A, 0, 0));
         }
         else if (exp == 1)
         {

--- a/bool_mat/randtest.c
+++ b/bool_mat/randtest.c
@@ -35,7 +35,7 @@ bool_mat_randtest(bool_mat_t mat, flint_rand_t state)
     density = n_randint(state, 101);
     for (i = 0; i < bool_mat_nrows(mat); i++)
         for (j = 0; j < bool_mat_ncols(mat); j++)
-            *bool_mat_entry(mat, i, j) = (n_randint(state, 100) < density);
+            bool_mat_set_entry(mat, i, j, n_randint(state, 100) < density);
 }
 
 void
@@ -49,7 +49,7 @@ bool_mat_randtest_diagonal(bool_mat_t mat, flint_rand_t state)
     density = n_randint(state, 101);
     bool_mat_zero(mat);
     for (i = 0; i < n; i++)
-        *bool_mat_entry(mat, i, i) = (n_randint(state, 100) < density);
+        bool_mat_set_entry(mat, i, i, n_randint(state, 100) < density);
 }
 
 void
@@ -76,7 +76,7 @@ bool_mat_randtest_nilpotent(bool_mat_t mat, flint_rand_t state)
 
     if (n == 1)
     {
-        *bool_mat_entry(mat, 0, 0) = 0;
+        bool_mat_set_entry(mat, 0, 0, 0);
         return;
     }
 
@@ -87,7 +87,7 @@ bool_mat_randtest_nilpotent(bool_mat_t mat, flint_rand_t state)
     {
         for (j = 0; j < i; j++)
         {
-            *bool_mat_entry(mat, i, j) = (n_randint(state, 100) < density);
+            bool_mat_set_entry(mat, i, j, n_randint(state, 100) < density);
         }
     }
 
@@ -106,7 +106,8 @@ bool_mat_randtest_nilpotent(bool_mat_t mat, flint_rand_t state)
         {
             for (j = 0; j < n; j++)
             {
-                *bool_mat_entry(mat, p[i], p[j]) = *bool_mat_entry(A, i, j);
+                bool_mat_set_entry(
+                        mat, p[i], p[j], bool_mat_get_entry(A, i, j));
             }
         }
 

--- a/bool_mat/set.c
+++ b/bool_mat/set.c
@@ -35,5 +35,5 @@ bool_mat_set(bool_mat_t dest, const bool_mat_t src)
 
     for (i = 0; i < bool_mat_nrows(src); i++)
         for (j = 0; j < bool_mat_ncols(src); j++)
-            *bool_mat_entry(dest, i, j) = *bool_mat_entry(src, i, j);
+            bool_mat_set_entry(dest, i, j, bool_mat_get_entry(src, i, j));
 }

--- a/bool_mat/test/t-all_pairs_longest_walk.c
+++ b/bool_mat/test/t-all_pairs_longest_walk.c
@@ -66,7 +66,8 @@ _bool_mat_permute(bool_mat_t B, const bool_mat_t A, const slong *perm)
     {
         for (j = 0; j < n; j++)
         {
-            *bool_mat_entry(B, perm[i], perm[j]) = *bool_mat_entry(A, i, j);
+            bool_mat_set_entry(
+                    B, perm[i], perm[j], bool_mat_get_entry(A, i, j));
         }
     }
 }
@@ -110,7 +111,7 @@ _brute_force_all_pairs_longest_walk(fmpz_mat_t B, const bool_mat_t A)
             {
                 for (j = 0; j < n; j++)
                 {
-                    if (*bool_mat_entry(T, i, j))
+                    if (bool_mat_get_entry(T, i, j))
                     {
                         fmpz_set_si(fmpz_mat_entry(B, i, j), k);
                     }
@@ -209,7 +210,7 @@ int main()
                 for (j = 0; j < m; j++)
                 {
                     slong x = fmpz_get_si(fmpz_mat_entry(B, i, j));
-                    *bool_mat_entry(V, i, j) = (x != -1 && x != 0);
+                    bool_mat_set_entry(V, i, j, (x != -1 && x != 0));
                 }
             }
 

--- a/bool_mat/test/t-complement.c
+++ b/bool_mat/test/t-complement.c
@@ -84,21 +84,38 @@ int main()
     for (iter = 0; iter < 10000; iter++)
     {
         slong m, n;
-        bool_mat_t A, C;
+        bool_mat_t A, C, CC;
 
         m = n_randint(state, 10) + 1;
         n = n_randint(state, 10) + 1;
 
         bool_mat_init(A, m, n);
         bool_mat_init(C, m, n);
+        bool_mat_init(CC, m, n);
 
         bool_mat_randtest(A, state);
         bool_mat_complement(C, A);
+        bool_mat_complement(CC, C);
 
         if ((bool_mat_all(A) && bool_mat_any(C)) ||
             (bool_mat_all(C) && bool_mat_any(A)))
         {
             flint_printf("FAIL\n");
+            abort();
+        }
+
+        /* involution */
+        if (!bool_mat_equal(A, CC))
+        {
+            flint_printf("FAIL (involution)\n");
+            abort();
+        }
+
+        /* aliasing */
+        bool_mat_complement(A, A);
+        if (!bool_mat_equal(A, C))
+        {
+            flint_printf("FAIL (aliasing)\n");
             abort();
         }
 

--- a/bool_mat/test/t-is_diagonal.c
+++ b/bool_mat/test/t-is_diagonal.c
@@ -101,7 +101,7 @@ int main()
             j = n_randint(state, n);
             if (i != j)
             {
-                *bool_mat_entry(A, i, j) = 1;
+                bool_mat_set_entry(A, i, j, 1);
                 if (bool_mat_is_diagonal(A))
                 {
                     flint_printf("FAIL (random non-diagonal)\n");

--- a/bool_mat/test/t-trace.c
+++ b/bool_mat/test/t-trace.c
@@ -96,7 +96,7 @@ int main()
         bool_mat_randtest(A, state);
 
         i = (slong) n_randint(state, n);
-        *bool_mat_entry(A, i, i) = 1;
+        bool_mat_set_entry(A, i, i, 1);
         if (bool_mat_trace(A) != 1)
         {
             flint_printf("FAIL (diagonal has a non-zero entry)\n");
@@ -106,7 +106,7 @@ int main()
 
         for (i = 0; i < n; i++)
         {
-            *bool_mat_entry(A, i, i) = 0;
+            bool_mat_set_entry(A, i, i, 0);
         }
         if (bool_mat_trace(A) != 0)
         {

--- a/bool_mat/test/t-transitive_closure.c
+++ b/bool_mat/test/t-transitive_closure.c
@@ -37,7 +37,8 @@ _bool_mat_permute(bool_mat_t B, const bool_mat_t A, const slong *perm)
     {
         for (j = 0; j < n; j++)
         {
-            *bool_mat_entry(B, perm[i], perm[j]) = *bool_mat_entry(A, i, j);
+            bool_mat_set_entry(
+                    B, perm[i], perm[j], bool_mat_get_entry(A, i, j));
         }
     }
 }

--- a/bool_mat/test/t-transpose.c
+++ b/bool_mat/test/t-transpose.c
@@ -38,44 +38,48 @@ int main()
     for (iter = 0; iter < 10000; iter++)
     {
         slong m, n;
-        bool_mat_t a, b, c;
+        bool_mat_t a, b;
 
         m = n_randint(state, 10);
         n = n_randint(state, 10);
 
         bool_mat_init(a, m, n);
         bool_mat_init(b, n, m);
-        bool_mat_init(c, m, n);
 
         bool_mat_randtest(a, state);
         bool_mat_randtest(b, state);
-        bool_mat_randtest(c, state);
 
         bool_mat_transpose(b, a);
-        bool_mat_transpose(c, b);
 
-        if (!bool_mat_equal(c, a))
+        /* involution */
         {
-            flint_printf("FAIL\n\n");
-            flint_printf("m = %wd, n = %wd\n", m, n);
-            abort();
+            bool_mat_t c;
+            bool_mat_init(c, m, n);
+            bool_mat_randtest(c, state);
+            bool_mat_transpose(c, b);
+            if (!bool_mat_equal(c, a))
+            {
+                flint_printf("FAIL (involution)\n");
+                flint_printf("m = %wd, n = %wd\n", m, n);
+                abort();
+            }
+            bool_mat_clear(c);
         }
 
-        if (bool_mat_nrows(a) == bool_mat_ncols(a))
+        /* aliasing */
+        if (bool_mat_is_square(a))
         {
-            bool_mat_transpose(c, a);
             bool_mat_transpose(a, a);
 
-            if (!bool_mat_equal(a, c))
+            if (!bool_mat_equal(a, b))
             {
-                flint_printf("FAIL (aliasing)\n\n");
+                flint_printf("FAIL (aliasing)\n");
                 abort();
             }
         }
 
         bool_mat_clear(a);
         bool_mat_clear(b);
-        bool_mat_clear(c);
     }
 
     flint_randclear(state);

--- a/bool_mat/trace.c
+++ b/bool_mat/trace.c
@@ -40,7 +40,7 @@ bool_mat_trace(const bool_mat_t mat)
         return 0;
 
     for (i = 0; i < bool_mat_nrows(mat); i++)
-        if (*bool_mat_entry(mat, i, i))
+        if (bool_mat_get_entry(mat, i, i))
             return 1;
 
     return 0;

--- a/bool_mat/transitive_closure.c
+++ b/bool_mat/transitive_closure.c
@@ -53,8 +53,12 @@ bool_mat_transitive_closure(bool_mat_t dest, const bool_mat_t src)
         {
             for (j = 0; j < dim; j++)
             {
-                *bool_mat_entry(dest, i, j) |= (*bool_mat_entry(dest, i, k) &
-                                                *bool_mat_entry(dest, k, j));
+                if (!bool_mat_get_entry(dest, i, j))
+                {
+                    bool_mat_set_entry(dest, i, j, (
+                                bool_mat_get_entry(dest, i, k) &
+                                bool_mat_get_entry(dest, k, j)));
+                }
             }
         }
     }

--- a/bool_mat/transpose.c
+++ b/bool_mat/transpose.c
@@ -43,13 +43,13 @@ bool_mat_transpose(bool_mat_t B, const bool_mat_t A)
     if (A == B)  /* In-place, guaranteed to be square */
     {
         int tmp;
-        for (i = 0; i < bool_mat_nrows(A) - 1; i++)
+        for (i = 0; i < bool_mat_nrows(B) - 1; i++)
         {
-            for (j = i + 1; j < bool_mat_ncols(A); j++)
+            for (j = i + 1; j < bool_mat_ncols(B); j++)
             {
-                tmp = *bool_mat_entry(A, i, j);
-                *bool_mat_entry(A, i, j) = *bool_mat_entry(A, j, i);
-                *bool_mat_entry(A, j, i) = tmp;
+                tmp = bool_mat_get_entry(B, i, j);
+                bool_mat_set_entry(B, i, j, bool_mat_get_entry(B, j, i));
+                bool_mat_set_entry(B, j, i, tmp);
             }
         }
     }
@@ -57,6 +57,6 @@ bool_mat_transpose(bool_mat_t B, const bool_mat_t A)
     {
         for (i = 0; i < bool_mat_nrows(B); i++)
             for (j = 0; j < bool_mat_ncols(B); j++)
-                *bool_mat_entry(B, i, j) = *bool_mat_entry(A, j, i);
+                bool_mat_set_entry(B, i, j, bool_mat_get_entry(A, j, i));
     }
 }

--- a/bool_mat/zero.c
+++ b/bool_mat/zero.c
@@ -32,5 +32,5 @@ bool_mat_zero(bool_mat_t mat)
 
     for (i = 0; i < bool_mat_nrows(mat); i++)
         for (j = 0; j < bool_mat_ncols(mat); j++)
-            *bool_mat_entry(mat, i, j) = 0;
+            bool_mat_set_entry(mat, i, j, 0);
 }

--- a/doc/source/bool_mat.rst
+++ b/doc/source/bool_mat.rst
@@ -28,9 +28,13 @@ Types, macros and constants
     *bool_mat_struct*, permitting an *bool_mat_t* to
     be passed by reference.
 
-.. macro:: bool_mat_entry(mat, i, j)
+.. function:: int bool_mat_get_entry(const bool_mat_t mat, slong i, slong j)
 
-    Macro giving a pointer to the entry at row *i* and column *j*.
+    Returns the entry of matrix *mat* at row *i* and column *j*.
+
+.. function:: void bool_mat_set_entry(bool_mat_t mat, slong i, slong j, int x)
+
+    Sets the entry of matrix *mat* at row *i* and column *j* to *x*.
 
 .. macro:: bool_mat_nrows(mat)
 


### PR DESCRIPTION
addresses https://github.com/fredrik-johansson/arb/pull/100#issuecomment-190920000

Uses `bool_mat_get_entry` and `bool_mat_set_entry` instead of `bool_mat_entry`.  Sometimes I'm unsure how to write notation in the docs, for example 'sets the entry to x' vs. 'sets the value of the entry to x', or if 'entry' and 'element' mean different things.