### PR TITLE
MAINT: fix mem leak in bool_mat complement involution test

### DIFF
--- a/bool_mat/test/t-complement.c
+++ b/bool_mat/test/t-complement.c
@@ -84,18 +84,17 @@ int main()
     for (iter = 0; iter < 10000; iter++)
     {
         slong m, n;
-        bool_mat_t A, C, CC;
+        bool_mat_t A, C;
 
         m = n_randint(state, 10) + 1;
         n = n_randint(state, 10) + 1;
 
         bool_mat_init(A, m, n);
         bool_mat_init(C, m, n);
-        bool_mat_init(CC, m, n);
 
         bool_mat_randtest(A, state);
+        bool_mat_randtest(C, state);
         bool_mat_complement(C, A);
-        bool_mat_complement(CC, C);
 
         if ((bool_mat_all(A) && bool_mat_any(C)) ||
             (bool_mat_all(C) && bool_mat_any(A)))
@@ -105,10 +104,17 @@ int main()
         }
 
         /* involution */
-        if (!bool_mat_equal(A, CC))
         {
-            flint_printf("FAIL (involution)\n");
-            abort();
+            bool_mat_t CC;
+            bool_mat_init(CC, m, n);
+            bool_mat_randtest(CC, state);
+            bool_mat_complement(CC, C);
+            if (!bool_mat_equal(A, CC))
+            {
+                flint_printf("FAIL (involution)\n");
+                abort();
+            }
+            bool_mat_clear(CC);
         }
 
         /* aliasing */


### PR DESCRIPTION
I wasn't clearing a bool_mat in one of the unit tests.

The valgrind tests could be streamlined to check a whole module at once for error/leaks. For this PR I am doing this by running `$ make valgrind MOD=bool_mat` and then inspecting `cat build/bool_mat/test/t-*.valgrind` visually for anything that looks like an error or leak, but it could be automated. It would also be nice if the number of iterations were reduced by maybe 10x when running valgrind, but I know that arb doesn't have that iteration control yet.