### PR TITLE
MAINT: remove _arb_vec_norm which did not actually compute a norm

### DIFF
--- a/arb.h
+++ b/arb.h
@@ -895,15 +895,6 @@ _arb_vec_dot(arb_t res, arb_srcptr vec1, arb_srcptr vec2, slong len2, slong prec
 }
 
 ARB_INLINE void
-_arb_vec_norm(arb_t res, arb_srcptr vec, slong len, slong prec)
-{
-    slong i;
-    arb_zero(res);
-    for (i = 0; i < len; i++)
-        arb_addmul(res, vec + i, vec + i, prec);
-}
-
-ARB_INLINE void
 _arb_vec_get_mag(mag_t bound, arb_srcptr vec, slong len)
 {
     if (len < 1)

--- a/doc/source/arb.rst
+++ b/doc/source/arb.rst
@@ -1558,10 +1558,6 @@ Vector functions
 
     Sets *res* to the dot product of *vec1* and *vec2*.
 
-.. function:: void _arb_vec_norm(arb_t res, arb_srcptr vec, slong len, slong prec)
-
-    Sets *res* to the dot product of *vec* with itself.
-
 .. function:: void _arb_vec_get_mag(mag_t bound, arb_srcptr vec, slong len, slong prec)
 
     Sets *bound* to an upper bound for the entries in *vec*.


### PR DESCRIPTION
related to https://github.com/fredrik-johansson/arb/issues/71

The `_arb_vec_get_mag` function also seems questionable to me. I would expect a function with that name to compute the magnitude of the vector. But it actually computes the vector infinity norm, which I'd expect to be named something like `_arb_vec_get_inf_norm`.