### PR TITLE
ENH: frobenius norm

### DIFF
--- a/acb_mat.h
+++ b/acb_mat.h
@@ -150,6 +150,8 @@ void acb_mat_transpose(acb_mat_t mat1, const acb_mat_t mat2);
 
 void acb_mat_bound_inf_norm(mag_t b, const acb_mat_t A);
 
+void acb_mat_bound_fro_norm(mag_t b, const acb_mat_t A);
+
 /* Arithmetic */
 
 void acb_mat_neg(acb_mat_t dest, const acb_mat_t src);

--- a/acb_mat/bound_fro_norm.c
+++ b/acb_mat/bound_fro_norm.c
@@ -1,0 +1,59 @@
+/*=============================================================================
+
+    This file is part of ARB.
+
+    ARB is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    ARB is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with ARB; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2016 Arb authors
+
+******************************************************************************/
+
+#include "acb_mat.h"
+
+void
+acb_mat_bound_fro_norm(mag_t b, const acb_mat_t A)
+{
+    slong i, j, r, c;
+    mag_t t;
+
+    r = acb_mat_nrows(A);
+    c = acb_mat_ncols(A);
+
+    mag_zero(b);
+
+    if (r == 0 || c == 0)
+        return;
+
+    mag_init(t);
+
+    for (i = 0; i < r; i++)
+    {
+        for (j = 0; j < c; j++)
+        {
+            acb_ptr z = acb_mat_entry(A, i, j);
+            arb_get_mag(t, acb_realref(z));
+            mag_addmul(b, t, t);
+            arb_get_mag(t, acb_imagref(z));
+            mag_addmul(b, t, t);
+        }
+    }
+
+    mag_sqrt(b, b);
+
+    mag_clear(t);
+}

--- a/acb_mat/test/t-trace.c
+++ b/acb_mat/test/t-trace.c
@@ -25,6 +25,16 @@
 
 #include "acb_mat.h"
 
+static void
+_acb_mat_conjugate_transpose(acb_mat_t B, const acb_mat_t A)
+{
+    slong i, j;
+    acb_mat_transpose(B, A);
+    for (i = 0; i < acb_mat_nrows(B); i++)
+        for (j = 0; j < acb_mat_ncols(B); j++)
+            acb_conj(acb_mat_entry(B, i, j), acb_mat_entry(B, i, j));
+}
+
 int main()
 {
     slong iter;
@@ -133,6 +143,65 @@ int main()
         acb_mat_clear(b);
         acb_mat_clear(ab);
         acb_mat_clear(ba);
+    }
+
+    /* check trace(A^H A) = frobenius_norm(A)^2 */
+    for (iter = 0; iter < 10000; iter++)
+    {
+        slong m, n, prec;
+        acb_mat_t A, AH, AHA;
+        acb_t t;
+        mag_t low, fro;
+
+        prec = 2 + n_randint(state, 200);
+
+        m = n_randint(state, 10);
+        n = n_randint(state, 10);
+
+        acb_mat_init(A, m, n);
+        acb_mat_randtest(A, state, 2 + n_randint(state, 100), 10);
+
+        acb_mat_init(AH, n, m);
+        _acb_mat_conjugate_transpose(AH, A);
+
+        acb_mat_init(AHA, n, n);
+        acb_mat_mul(AHA, AH, A, prec);
+
+        acb_init(t);
+        acb_mat_trace(t, AHA, prec);
+        acb_sqrt(t, t, prec);
+
+        mag_init(low);
+        acb_get_mag_lower(low, t);
+
+        mag_init(fro);
+        acb_mat_bound_fro_norm(fro, A);
+
+        if (mag_cmp(low, fro) > 0)
+        {
+            flint_printf("FAIL (frobenius norm)\n", iter);
+            flint_printf("m = %wd, n = %wd, prec = %wd\n", m, n, prec);
+            flint_printf("\n");
+
+            flint_printf("A = \n"); acb_mat_printd(A, 15); flint_printf("\n\n");
+
+            flint_printf("lower(sqrt(trace(A^H A))) = \n");
+            mag_printd(low, 15); flint_printf("\n\n");
+
+            flint_printf("upper(frobenius_norm(A)) = \n");
+            mag_printd(fro, 15); flint_printf("\n\n");
+
+            abort();
+        }
+
+        acb_clear(t);
+
+        mag_clear(low);
+        mag_clear(fro);
+
+        acb_mat_clear(A);
+        acb_mat_clear(AH);
+        acb_mat_clear(AHA);
     }
 
     flint_randclear(state);

--- a/arb_mat.h
+++ b/arb_mat.h
@@ -142,6 +142,8 @@ void arb_mat_transpose(arb_mat_t mat1, const arb_mat_t mat2);
 
 void arb_mat_bound_inf_norm(mag_t b, const arb_mat_t A);
 
+void arb_mat_bound_fro_norm(mag_t b, const arb_mat_t A);
+
 /* Arithmetic */
 
 void arb_mat_neg(arb_mat_t dest, const arb_mat_t src);

--- a/arb_mat/bound_fro_norm.c
+++ b/arb_mat/bound_fro_norm.c
@@ -1,0 +1,56 @@
+/*=============================================================================
+
+    This file is part of ARB.
+
+    ARB is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    ARB is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with ARB; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2016 Arb authors
+
+******************************************************************************/
+
+#include "arb_mat.h"
+
+void
+arb_mat_bound_fro_norm(mag_t b, const arb_mat_t A)
+{
+    slong i, j, r, c;
+    mag_t t;
+
+    r = arb_mat_nrows(A);
+    c = arb_mat_ncols(A);
+
+    mag_zero(b);
+
+    if (r == 0 || c == 0)
+        return;
+
+    mag_init(t);
+
+    for (i = 0; i < r; i++)
+    {
+        for (j = 0; j < c; j++)
+        {
+            arb_get_mag(t, arb_mat_entry(A, i, j));
+            mag_addmul(b, t, t);
+        }
+    }
+
+    mag_sqrt(b, b);
+
+    mag_clear(t);
+}

--- a/arb_mat/test/t-trace.c
+++ b/arb_mat/test/t-trace.c
@@ -124,6 +124,7 @@ int main()
 
             flint_printf("trace(ab) = \n"); arb_printd(trab, 15); flint_printf("\n\n");
             flint_printf("trace(ba) = \n"); arb_printd(trba, 15); flint_printf("\n\n");
+            abort();
         }
 
         arb_clear(trab);
@@ -133,6 +134,65 @@ int main()
         arb_mat_clear(b);
         arb_mat_clear(ab);
         arb_mat_clear(ba);
+    }
+
+    /* check trace(A^T A) = frobenius_norm(A)^2 */
+    for (iter = 0; iter < 10000; iter++)
+    {
+        slong m, n, prec;
+        arb_mat_t A, AT, ATA;
+        arb_t t;
+        mag_t low, fro;
+
+        prec = 2 + n_randint(state, 200);
+
+        m = n_randint(state, 10);
+        n = n_randint(state, 10);
+
+        arb_mat_init(A, m, n);
+        arb_mat_randtest(A, state, 2 + n_randint(state, 100), 10);
+
+        arb_mat_init(AT, n, m);
+        arb_mat_transpose(AT, A);
+
+        arb_mat_init(ATA, n, n);
+        arb_mat_mul(ATA, AT, A, prec);
+
+        arb_init(t);
+        arb_mat_trace(t, ATA, prec);
+        arb_sqrt(t, t, prec);
+
+        mag_init(low);
+        arb_get_mag_lower(low, t);
+
+        mag_init(fro);
+        arb_mat_bound_fro_norm(fro, A);
+
+        if (mag_cmp(low, fro) > 0)
+        {
+            flint_printf("FAIL (frobenius norm)\n", iter);
+            flint_printf("m = %wd, n = %wd, prec = %wd\n", m, n, prec);
+            flint_printf("\n");
+
+            flint_printf("A = \n"); arb_mat_printd(A, 15); flint_printf("\n\n");
+
+            flint_printf("lower(sqrt(trace(A^T A))) = \n");
+            mag_printd(low, 15); flint_printf("\n\n");
+
+            flint_printf("upper(frobenius_norm(A)) = \n");
+            mag_printd(fro, 15); flint_printf("\n\n");
+
+            abort();
+        }
+
+        arb_clear(t);
+
+        mag_clear(low);
+        mag_clear(fro);
+
+        arb_mat_clear(A);
+        arb_mat_clear(AT);
+        arb_mat_clear(ATA);
     }
 
     flint_randclear(state);

--- a/doc/source/acb_mat.rst
+++ b/doc/source/acb_mat.rst
@@ -161,6 +161,11 @@ Norms
     Sets *b* to an upper bound for the infinity norm (i.e. the largest
     absolute value row sum) of *A*.
 
+.. function:: void acb_mat_bound_fro_norm(mag_t b, const acb_mat_t A)
+
+    Sets *b* to an upper bound for the Frobenius norm (i.e. the square root
+    of the sum of squares of magnitudes of entries) of *A*.
+
 
 Arithmetic
 -------------------------------------------------------------------------------

--- a/doc/source/arb_mat.rst
+++ b/doc/source/arb_mat.rst
@@ -152,6 +152,11 @@ Norms
     Sets *b* to an upper bound for the infinity norm (i.e. the largest
     absolute value row sum) of *A*.
 
+.. function:: void arb_mat_bound_fro_norm(mag_t b, const arb_mat_t A)
+
+    Sets *b* to an upper bound for the Frobenius norm (i.e. the square root
+    of the sum of squares of entries) of *A*.
+
 Arithmetic
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
Includes docs, and an identity involving this norm and the matrix trace has been added to the trace tests. It's implemented for real and complex matrices. A variant that computes an `arb_t` interval instead of a `mag_t` upper bound could be useful too, but that is not implemented here.