### PR TITLE
Travis CI

### DIFF
--- a/.build_dependencies
+++ b/.build_dependencies
@@ -1,0 +1,26 @@
+#! /bin/sh
+
+wget http://mpir.org/mpir-2.7.0.tar.bz2
+tar -xf mpir-2.7.0.tar.bz2
+cd mpir-2.7.0
+./configure --enable-gmpcompat --prefix=$HOME/deps
+make -j4 > /dev/null 2>&1
+make install
+cd ..
+
+wget http://www.mpfr.org/mpfr-current/mpfr-3.1.4.tar.bz2
+tar -xf mpfr-3.1.4.tar.bz2
+cd mpfr-3.1.4
+./configure --with-gmp=$HOME/deps --prefix=$HOME/deps
+make -j4 > /dev/null 2>&1
+make install
+cd ..
+
+wget wget https://github.com/wbhart/flint2/archive/trunk.tar.gz
+tar -xf trunk.tar.gz
+cd flint2-trunk
+./configure --with-gmp=$HOME/deps --with-mpfr=$HOME/deps --prefix=$HOME/deps
+make -j4 > /dev/null 2>&1
+make install
+cd ..
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ script:
         export CC=gcc-4.8;
         export CXX=g++-4.8;
     fi
+  - if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
+        export ARB_TEST_MULTIPLIER=0.1;
+    fi
   - ./.build_dependencies
   - ./configure --with-mpir=$HOME/deps --with-mpfr=$HOME/deps --with-flint=$HOME/deps
   - make -j4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: c
+sudo: false
+addons:
+  apt:
+    packages:
+      - texinfo
+
+os:
+  - osx
+  - linux
+
+compiler:
+  - gcc
+  - clang
+
+script:
+  - if [[ "${TRAVIS_OS_NAME}" == "osx" ]] && [[ "${CC}" == "gcc" ]]; then
+        export CC=gcc-4.8;
+        export CXX=g++-4.8;
+    fi
+  - ./.build_dependencies
+  - ./configure --with-mpir=$HOME/deps --with-mpfr=$HOME/deps --with-flint=$HOME/deps
+  - make -j4
+  - make check
+


### PR DESCRIPTION
OS X test with gcc timeouts.

@fredrik-johansson, you mentioned in symengine/symengine#877 that the tests could be reduced with something like `flint_test_multiplier()`. How do I do that?