### PR TITLE
add convenient print functions

### DIFF
--- a/arb.h
+++ b/arb.h
@@ -277,6 +277,13 @@ arb_print(const arb_t x)
 }
 
 ARB_INLINE void
+arb_println(const arb_t x)
+{
+    arb_fprint(stdout, x);
+    printf("\n");
+}
+
+ARB_INLINE void
 arb_printd(const arb_t x, slong digits)
 {
     arb_fprintd(stdout, x, digits);


### PR DESCRIPTION
I find myself often implementing print like functions that will print new lines for convenience. If you agree that this change would be worthwhile I can do this for other types within this merge request.

If you'd like to add these functions, would you like documentation as well?

I named the function arb_println because it is similar to the name java uses which I believe is out_println.