### PR TITLE
Build Extension Module Examples, add arb_sqr and acb_sqr

### DIFF
--- a/acb.h
+++ b/acb.h
@@ -814,7 +814,7 @@ void acb_agm1(acb_t m, const acb_t z, slong prec);
 void acb_agm1_cpx(acb_ptr m, const acb_t z, slong len, slong prec);
 
 ACB_INLINE void
-acb_sqr(acb_t res, acb_t val, slong prec)
+acb_sqr(acb_t res, const acb_t val, slong prec)
 {
     acb_mul(res, val, val, prec);
 }

--- a/acb.h
+++ b/acb.h
@@ -813,6 +813,12 @@ void acb_polylog_si(acb_t w, slong s, const acb_t z, slong prec);
 void acb_agm1(acb_t m, const acb_t z, slong prec);
 void acb_agm1_cpx(acb_ptr m, const acb_t z, slong len, slong prec);
 
+ACB_INLINE void
+acb_sqr(acb_t res, acb_t val, slong prec)
+{
+    acb_mul(res, val, val, prec);
+}
+
 /*
 TBD
 

--- a/arb.h
+++ b/arb.h
@@ -730,6 +730,12 @@ void arb_euler_number_ui(arb_t res, ulong n, slong prec);
 void arb_partitions_fmpz(arb_t res, const fmpz_t n, slong prec);
 void arb_partitions_ui(arb_t res, ulong n, slong prec);
 
+ARB_INLINE void
+arb_sqr(arb_t res, const acb_t val, slong prec)
+{
+    arb_mul(res, val, val, prec);
+}
+
 #define ARB_DEF_CACHED_CONSTANT(name, comp_func) \
     TLS_PREFIX slong name ## _cached_prec = 0; \
     TLS_PREFIX arb_t name ## _cached_value; \

--- a/arb.h
+++ b/arb.h
@@ -731,7 +731,7 @@ void arb_partitions_fmpz(arb_t res, const fmpz_t n, slong prec);
 void arb_partitions_ui(arb_t res, ulong n, slong prec);
 
 ARB_INLINE void
-arb_sqr(arb_t res, const acb_t val, slong prec)
+arb_sqr(arb_t res, const arb_t val, slong prec)
 {
     arb_mul(res, val, val, prec);
 }

--- a/configure
+++ b/configure
@@ -590,6 +590,11 @@ CONFIG_PTHREAD="#define HAVE_PTHREAD ${PTHREAD}"
 
 EXTRA_INC_DIRS="${EXTRA_INC_DIRS} ${EXTENSIONS}"
 
+
+if [ -d "${EXTENSIONS}/examples" ]; then
+   cp ${EXTENSIONS}/examples/*.c ./examples/
+fi
+
 #include paths
 
 INCS="-I\$(CURDIR)"

--- a/doc/source/acb.rst
+++ b/doc/source/acb.rst
@@ -410,6 +410,10 @@ Arithmetic
 
     Sets *z* to *x* multiplied by `2^e`, without rounding.
 
+.. function:: void acb_sqr(acb_t z, const acb_t x, slong prec)
+
+    Sets *z* to *x* squared.
+
 .. function:: void acb_cube(acb_t z, const acb_t x, slong prec)
 
     Sets *z* to *x* cubed, computed efficiently using two real squarings,

--- a/doc/source/arb.rst
+++ b/doc/source/arb.rst
@@ -797,6 +797,10 @@ Powers and roots
 
     Alias for :func:`arb_root_ui`, provided for backwards compatibility.
 
+.. function:: void arb_sqr(arb_t y, const arb_t x, slong prec)
+
+    Sets *y* to be the square of *x*. 
+
 .. function:: void arb_pow_fmpz_binexp(arb_t y, const arb_t b, const fmpz_t e, slong prec)
 
 .. function:: void arb_pow_fmpz(arb_t y, const arb_t b, const fmpz_t e, slong prec)


### PR DESCRIPTION
This fixes issue #135, although not an elegant fix.  

Add function arb_sqr requested in issue #113  as well as acb_sqr and documentation.