### PR TITLE
ENH: add incomplete gamma lower series

### DIFF
--- a/acb_hypgeom.h
+++ b/acb_hypgeom.h
@@ -131,6 +131,9 @@ void acb_hypgeom_gamma_upper_series(acb_poly_t g, const acb_t s, const acb_poly_
 
 void acb_hypgeom_gamma_lower(acb_t res, const acb_t s, const acb_t z, int modified, slong prec);
 
+void _acb_hypgeom_gamma_lower_series(acb_ptr g, const acb_t s, acb_srcptr h, slong hlen, int regularized, slong n, slong prec);
+void acb_hypgeom_gamma_lower_series(acb_poly_t g, const acb_t s, const acb_poly_t h, int regularized, slong n, slong prec);
+
 void acb_hypgeom_expint(acb_t res, const acb_t s, const acb_t z, slong prec);
 
 void acb_hypgeom_erf_propagated_error(mag_t re, mag_t im, const acb_t z);

--- a/acb_hypgeom/gamma_lower_series.c
+++ b/acb_hypgeom/gamma_lower_series.c
@@ -1,0 +1,121 @@
+/*=============================================================================
+
+    This file is part of ARB.
+
+    ARB is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    ARB is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with ARB; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2016 Arb authors
+
+******************************************************************************/
+
+#include "acb_poly.h"
+#include "acb_hypgeom.h"
+
+void
+_acb_hypgeom_gamma_lower_series(acb_ptr g, const acb_t s, acb_srcptr h, slong hlen, int regularized, slong n, slong prec)
+{
+    acb_t c;
+    acb_init(c);
+
+    acb_hypgeom_gamma_lower(c, s, h, regularized, prec);
+
+    hlen = FLINT_MIN(hlen, n);
+
+    if (hlen == 1)
+    {
+        _acb_vec_zero(g + 1, n - 1);
+    }
+    else
+    {
+        acb_ptr t, u, v;
+        acb_ptr w = NULL;
+
+        t = _acb_vec_init(n);
+        u = _acb_vec_init(n);
+        v = _acb_vec_init(n);
+
+        if (regularized == 2)
+        {
+            w = _acb_vec_init(n);
+            acb_neg(t, s);
+            _acb_poly_pow_acb_series(w, h, hlen, t, n, prec);
+        }
+
+        /* gamma(s, h(x)) = integral(h'(x) h(x)^(s-1) exp(-h(x)) */
+        acb_sub_ui(u, s, 1, prec);
+        _acb_poly_pow_acb_series(t, h, hlen, u, n, prec);
+        _acb_poly_derivative(u, h, hlen, prec);
+        _acb_poly_mullow(v, t, n, u, hlen - 1, n, prec);
+        _acb_vec_neg(t, h, hlen);
+        _acb_poly_exp_series(t, t, hlen, n, prec);
+        _acb_poly_mullow(g, v, n, t, n, n, prec);
+        _acb_poly_integral(g, g, n, prec);
+
+        if (regularized == 1)
+        {
+            acb_rgamma(t, s, prec);
+            _acb_vec_scalar_mul(g, g, n, t, prec);
+        }
+        else if (regularized == 2)
+        {
+            acb_rgamma(t, s, prec);
+            _acb_vec_scalar_mul(g, g, n, t, prec);
+            _acb_vec_set(u, g, n);
+            _acb_poly_mullow(g, u, n, w, n, n, prec);
+            _acb_vec_clear(w, n);
+        }
+
+        _acb_vec_clear(t, n);
+        _acb_vec_clear(u, n);
+        _acb_vec_clear(v, n);
+    }
+
+    acb_swap(g, c);
+    acb_clear(c);
+}
+
+void
+acb_hypgeom_gamma_lower_series(acb_poly_t g, const acb_t s,
+        const acb_poly_t h, int regularized, slong n, slong prec)
+{
+    slong hlen = h->length;
+
+    if (n == 0)
+    {
+        acb_poly_zero(g);
+        return;
+    }
+
+    acb_poly_fit_length(g, n);
+
+    if (hlen == 0)
+    {
+        acb_t t;
+        acb_init(t);
+        _acb_hypgeom_gamma_lower_series(g->coeffs, s, t, 1, regularized, n, prec);
+        acb_clear(t);
+    }
+    else
+    {
+        _acb_hypgeom_gamma_lower_series(
+                g->coeffs, s, h->coeffs, hlen, regularized, n, prec);
+    }
+
+    _acb_poly_set_length(g, n);
+    _acb_poly_normalise(g);
+}

--- a/acb_hypgeom/gamma_lower_series.c
+++ b/acb_hypgeom/gamma_lower_series.c
@@ -93,7 +93,19 @@ void
 acb_hypgeom_gamma_lower_series(acb_poly_t g, const acb_t s,
         const acb_poly_t h, int regularized, slong n, slong prec)
 {
-    slong hlen = h->length;
+    slong hlen;
+
+    if (regularized == 2 && acb_is_int(s) &&
+        arf_sgn(arb_midref(acb_realref(s))) <= 0 &&
+        arf_cmpabs_2exp_si(arb_midref(acb_realref(s)), 30) < 0)
+    {
+        /* fixme: deliberate typo, add negative sign */
+        slong exp = arf_get_si(arb_midref(acb_realref(s)), ARF_RND_DOWN);
+        acb_poly_pow_ui_trunc_binexp(g, h, (ulong) exp, n, prec);
+        return;
+    }
+
+    hlen = h->length;
 
     if (n == 0)
     {

--- a/acb_hypgeom/gamma_lower_series.c
+++ b/acb_hypgeom/gamma_lower_series.c
@@ -19,9 +19,7 @@ _acb_hypgeom_gamma_lower_series(acb_ptr g, const acb_t s, acb_srcptr h, slong hl
 
     hlen = FLINT_MIN(hlen, n);
 
-    if (regularized == 2 && acb_is_int(s) &&
-        arf_sgn(arb_midref(acb_realref(s))) <= 0 &&
-        arf_cmpabs_2exp_si(arb_midref(acb_realref(s)), 30) < 0)
+    if (regularized == 2 && acb_is_int(s) && arb_is_nonpositive(acb_realref(s)))
     {
         acb_t ns;
         acb_init(ns);

--- a/acb_hypgeom/gamma_lower_series.c
+++ b/acb_hypgeom/gamma_lower_series.c
@@ -1,27 +1,13 @@
-/*=============================================================================
-
-    This file is part of ARB.
-
-    ARB is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 2 of the License, or
-    (at your option) any later version.
-
-    ARB is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with ARB; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
-
-=============================================================================*/
-/******************************************************************************
-
+/*
     Copyright (C) 2016 Arb authors
 
-******************************************************************************/
+    This file is part of Arb.
+
+    Arb is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
 
 #include "acb_poly.h"
 #include "acb_hypgeom.h"

--- a/acb_hypgeom/gamma_lower_series.c
+++ b/acb_hypgeom/gamma_lower_series.c
@@ -99,8 +99,7 @@ acb_hypgeom_gamma_lower_series(acb_poly_t g, const acb_t s,
         arf_sgn(arb_midref(acb_realref(s))) <= 0 &&
         arf_cmpabs_2exp_si(arb_midref(acb_realref(s)), 30) < 0)
     {
-        /* fixme: deliberate typo, add negative sign */
-        slong exp = arf_get_si(arb_midref(acb_realref(s)), ARF_RND_DOWN);
+        slong exp = -arf_get_si(arb_midref(acb_realref(s)), ARF_RND_DOWN);
         acb_poly_pow_ui_trunc_binexp(g, h, (ulong) exp, n, prec);
         return;
     }

--- a/acb_hypgeom/test/t-gamma_lower_series.c
+++ b/acb_hypgeom/test/t-gamma_lower_series.c
@@ -1,0 +1,181 @@
+/*=============================================================================
+
+    This file is part of ARB.
+
+    ARB is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    ARB is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with ARB; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2016 Arb authors
+
+******************************************************************************/
+
+#include "acb_poly.h"
+#include "acb_hypgeom.h"
+
+int main()
+{
+    slong iter;
+    flint_rand_t state;
+
+    flint_printf("gamma_lower_series....");
+    fflush(stdout);
+
+    flint_randinit(state);
+
+    for (iter = 0; iter < 1000 * arb_test_multiplier(); iter++)
+    {
+        slong m, n1, n2, bits1, bits2, bits3;
+        acb_poly_t S, A, B, C;
+        acb_t s, t, c;
+        int regularized;
+
+        regularized = n_randint(state, 3);
+
+        bits1 = 2 + n_randint(state, 200);
+        bits2 = 2 + n_randint(state, 200);
+        bits3 = 2 + n_randint(state, 200);
+
+        m = 1 + n_randint(state, 10);
+        n1 = 1 + n_randint(state, 10);
+        n2 = 1 + n_randint(state, 10);
+
+        acb_poly_init(S);
+        acb_poly_init(A);
+        acb_poly_init(B);
+        acb_poly_init(C);
+        acb_init(s);
+        acb_init(t);
+        acb_init(c);
+
+        acb_poly_randtest(S, state, m, bits1, 3);
+        acb_poly_randtest(A, state, m, bits1, 3);
+        acb_poly_randtest(B, state, m, bits1, 3);
+        acb_randtest(s, state, bits1, 3);
+
+        acb_hypgeom_gamma_lower_series(A, s, S, regularized, n1, bits2);
+        acb_hypgeom_gamma_lower_series(B, s, S, regularized, n2, bits3);
+
+        acb_poly_set(C, A);
+        acb_poly_truncate(C, FLINT_MIN(n1, n2));
+        acb_poly_truncate(B, FLINT_MIN(n1, n2));
+
+        if (!acb_poly_overlaps(B, C))
+        {
+            flint_printf("FAIL (consistency)\n\n");
+            flint_printf("regularized = %d\n\n", regularized);
+            flint_printf("S = "); acb_poly_printd(S, 15); flint_printf("\n\n");
+            flint_printf("A = "); acb_poly_printd(A, 15); flint_printf("\n\n");
+            flint_printf("B = "); acb_poly_printd(B, 15); flint_printf("\n\n");
+            flint_printf("C = "); acb_poly_printd(C, 15); flint_printf("\n\n");
+            abort();
+        }
+
+        /* f(h(x)) = exp(-h(x)) h(x)^(s-1) */
+        acb_poly_neg(C, S);
+        acb_poly_exp_series(C, C, n1, bits2);
+        acb_sub_ui(t, s, 1, bits2);
+        acb_poly_pow_acb_series(B, S, t, n1, bits2);
+        acb_poly_mullow(C, C, B, n1, bits2);
+
+        if (regularized == 0)
+        {
+            /* integral(f(h(x)) h'(x))' = f(h(x)) h'(x) */
+            acb_poly_derivative(B, S, bits2);
+            acb_poly_mullow(C, C, B, n1, bits2);
+
+            acb_poly_truncate(C, n1 - 1);
+        }
+        else if (regularized == 1)
+        {
+            /* (integral(f(h(x)) h'(x)) / c)' = (f(h(x)) h'(x)) / c */
+            acb_poly_derivative(B, S, bits2);
+            acb_poly_mullow(C, C, B, n1, bits2);
+
+            acb_gamma(c, s, bits2);
+            _acb_vec_scalar_div(C->coeffs, C->coeffs, C->length, c, bits2);
+
+            acb_poly_truncate(C, n1 - 1);
+        }
+        else if (regularized == 2)
+        {
+            /* (h(x)^-s integral(f(h(x)) h'(x)) / c)' =
+             * h(x)^-(s+1) (h(x) f(h(x)) - s integral(f(h(x)) h'(x))) h'(x) / c */
+            acb_poly_t D;
+            acb_poly_init(D);
+
+            acb_poly_derivative(B, S, bits2);
+            acb_poly_mullow(D, C, B, n1, bits2);
+            acb_poly_integral(D, D, bits2);
+            _acb_vec_scalar_mul(D->coeffs, D->coeffs, D->length, s, bits2);
+            acb_poly_mullow(C, C, S, n1, bits2);
+            acb_poly_sub(D, C, D, bits2);
+
+            acb_add_ui(t, s, 1, bits2);
+            acb_neg(t, t);
+            acb_poly_pow_acb_series(B, S, t, n1, bits2);
+
+            acb_poly_mullow(C, D, B, n1, bits2);
+
+            acb_poly_derivative(B, S, bits2);
+            acb_poly_mullow(C, C, B, n1, bits2);
+
+            acb_gamma(c, s, bits2);
+            _acb_vec_scalar_div(C->coeffs, C->coeffs, C->length, c, bits2);
+
+            acb_poly_truncate(C, n1 - 1);
+
+            acb_poly_clear(D);
+        }
+
+        acb_poly_derivative(B, A, bits2);
+
+        if (!acb_poly_overlaps(B, C))
+        {
+            flint_printf("FAIL (derivative)\n\n");
+            flint_printf("regularized = %d\n\n", regularized);
+            flint_printf("S = "); acb_poly_printd(S, 15); flint_printf("\n\n");
+            flint_printf("A = "); acb_poly_printd(A, 15); flint_printf("\n\n");
+            flint_printf("B = "); acb_poly_printd(B, 15); flint_printf("\n\n");
+            flint_printf("C = "); acb_poly_printd(C, 15); flint_printf("\n\n");
+            abort();
+        }
+
+        acb_hypgeom_gamma_lower_series(S, s, S, regularized, n1, bits2);
+
+        if (!acb_poly_overlaps(A, S))
+        {
+            flint_printf("FAIL (aliasing)\n\n");
+            flint_printf("regularized = %d\n\n", regularized);
+            flint_printf("S = "); acb_poly_printd(S, 15); flint_printf("\n\n");
+            flint_printf("A = "); acb_poly_printd(A, 15); flint_printf("\n\n");
+            abort();
+        }
+
+        acb_poly_clear(S);
+        acb_poly_clear(A);
+        acb_poly_clear(B);
+        acb_poly_clear(C);
+        acb_clear(s);
+        acb_clear(t);
+        acb_clear(c);
+    }
+
+    flint_randclear(state);
+    flint_cleanup();
+    flint_printf("PASS\n");
+    return EXIT_SUCCESS;
+}

--- a/acb_hypgeom/test/t-gamma_lower_series.c
+++ b/acb_hypgeom/test/t-gamma_lower_series.c
@@ -57,8 +57,11 @@ int main()
         }
         else
         {
-            slong p = n_randint(state, 100);
-            acb_set_d(s, -p);
+            fmpz_t k;
+            fmpz_init(k);
+            fmpz_randtest(k, state, 100);
+            acb_set_fmpz(s, k);
+            fmpz_clear(k);
         }
 
         acb_hypgeom_gamma_lower_series(A, s, S, regularized, n1, bits2);

--- a/acb_hypgeom/test/t-gamma_lower_series.c
+++ b/acb_hypgeom/test/t-gamma_lower_series.c
@@ -1,27 +1,13 @@
-/*=============================================================================
-
-    This file is part of ARB.
-
-    ARB is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 2 of the License, or
-    (at your option) any later version.
-
-    ARB is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with ARB; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
-
-=============================================================================*/
-/******************************************************************************
-
+/*
     Copyright (C) 2016 Arb authors
 
-******************************************************************************/
+    This file is part of Arb.
+
+    Arb is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
 
 #include "acb_poly.h"
 #include "acb_hypgeom.h"

--- a/doc/source/acb_hypgeom.rst
+++ b/doc/source/acb_hypgeom.rst
@@ -610,6 +610,15 @@ Incomplete gamma functions
     If *regularized* is 2, computes a further regularized lower incomplete
     gamma function `\gamma^{*}(s,z) = z^{-s} P(s,z)`.
 
+.. function:: void _acb_hypgeom_gamma_lower_series(acb_ptr res, acb_t s, acb_srcptr z, slong zlen, int regularized, slong n, slong prec)
+
+.. function:: void acb_hypgeom_gamma_lower_series(acb_poly_t res, const acb_t s, const acb_poly_t z, int regularized, slong n, slong prec)
+
+    Sets *res* to an lower incomplete gamma function where *s* is
+    a constant and *z* is a power series, truncated to length *n*.
+    The *regularized* argument has the same interpretation as in
+    :func:`acb_hypgeom_gamma_lower`.
+
 Exponential and trigonometric integrals
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
This is mostly copypasted from gamma upper series. For regularized=0 or regularized=1, higher order coefficients in the lower series should be negatives of the corresponding coefficients in the upper series. Regularization option 2 is defined slightly differently for lower vs. upper gamma, by a factor of Gamma(s).