### PR TITLE
ENH: arb_is_indeterminate

### DIFF
--- a/arb.h
+++ b/arb.h
@@ -158,6 +158,12 @@ arb_is_finite(const arb_t x)
     return arf_is_finite(arb_midref(x)) && mag_is_finite(arb_radref(x));
 }
 
+ARB_INLINE int
+arb_is_indeterminate(const arb_t x)
+{
+    return arf_is_nan(arb_midref(x));
+}
+
 void arb_set(arb_t x, const arb_t y);
 
 ARB_INLINE void
@@ -312,7 +318,7 @@ arb_is_positive(const arb_t x)
 {
     return (arf_sgn(arb_midref(x)) > 0) &&
         (arf_mag_cmpabs(arb_radref(x), arb_midref(x)) < 0) &&
-         !arf_is_nan(arb_midref(x));
+         !arb_is_indeterminate(x);
 }
 
 ARB_INLINE int
@@ -320,7 +326,7 @@ arb_is_nonnegative(const arb_t x)
 {
     return (arf_sgn(arb_midref(x)) >= 0) &&
         (arf_mag_cmpabs(arb_radref(x), arb_midref(x)) <= 0) &&
-         !arf_is_nan(arb_midref(x));
+         !arb_is_indeterminate(x);
 }
 
 ARB_INLINE int
@@ -328,7 +334,7 @@ arb_is_negative(const arb_t x)
 {
     return (arf_sgn(arb_midref(x)) < 0) &&
         (arf_mag_cmpabs(arb_radref(x), arb_midref(x)) < 0) &&
-         !arf_is_nan(arb_midref(x));
+         !arb_is_indeterminate(x);
 }
 
 ARB_INLINE int
@@ -336,7 +342,7 @@ arb_is_nonpositive(const arb_t x)
 {
     return (arf_sgn(arb_midref(x)) <= 0) &&
         (arf_mag_cmpabs(arb_radref(x), arb_midref(x)) <= 0) &&
-         !arf_is_nan(arb_midref(x));
+         !arb_is_indeterminate(x);
 }
 
 ARB_INLINE int
@@ -344,7 +350,7 @@ arb_contains_negative(const arb_t x)
 {
     return (arf_sgn(arb_midref(x)) < 0) ||
         (arf_mag_cmpabs(arb_radref(x), arb_midref(x)) > 0)
-        || arf_is_nan(arb_midref(x));
+        || arb_is_indeterminate(x);
 }
 
 ARB_INLINE int
@@ -352,7 +358,7 @@ arb_contains_nonpositive(const arb_t x)
 {
     return (arf_sgn(arb_midref(x)) <= 0) ||
         (arf_mag_cmpabs(arb_radref(x), arb_midref(x)) >= 0)
-        || arf_is_nan(arb_midref(x));
+        || arb_is_indeterminate(x);
 }
 
 ARB_INLINE int
@@ -360,7 +366,7 @@ arb_contains_positive(const arb_t x)
 {
     return (arf_sgn(arb_midref(x)) > 0) ||
         (arf_mag_cmpabs(arb_radref(x), arb_midref(x)) > 0)
-        || arf_is_nan(arb_midref(x));
+        || arb_is_indeterminate(x);
 }
 
 ARB_INLINE int
@@ -368,7 +374,7 @@ arb_contains_nonnegative(const arb_t x)
 {
     return (arf_sgn(arb_midref(x)) >= 0) ||
         (arf_mag_cmpabs(arb_radref(x), arb_midref(x)) >= 0)
-        || arf_is_nan(arb_midref(x));
+        || arb_is_indeterminate(x);
 }
 
 void arb_get_mag_lower(mag_t z, const arb_t x);

--- a/arb/contains.c
+++ b/arb/contains.c
@@ -23,8 +23,8 @@ arb_contains(const arb_t x, const arb_t y)
     if (arb_is_exact(y))
         return arb_contains_arf(x, arb_midref(y));
 
-    if (arf_is_nan(arb_midref(y)))
-        return arf_is_nan(arb_midref(x));
+    if (arb_is_indeterminate(y))
+        return arb_is_indeterminate(x);
 
     arf_init(t);
     arf_init(u);

--- a/arb/contains_arf.c
+++ b/arb/contains_arf.c
@@ -16,9 +16,9 @@ arb_contains_arf(const arb_t x, const arf_t y)
 {
     if (arf_is_nan(y))
     {
-        return arf_is_nan(arb_midref(x));
+        return arb_is_indeterminate(x);
     }
-    else if (arf_is_nan(arb_midref(x)))
+    else if (arb_is_indeterminate(x))
     {
         return 1;
     }

--- a/arb/div.c
+++ b/arb/div.c
@@ -19,7 +19,7 @@ arb_div_arf(arb_t z, const arb_t x, const arf_t y, slong prec)
 
     if (arf_is_zero(y))
     {
-        if (arf_is_nan(arb_midref(x)))
+        if (arb_is_indeterminate(x))
             arb_indeterminate(z);
         else
             arb_zero_pm_inf(z);

--- a/arb/get_str.c
+++ b/arb/get_str.c
@@ -308,7 +308,7 @@ arb_get_str_parts(int * negative, char **mid_digits, fmpz_t mid_exp,
 
         fmpz_zero(mid_exp);
         *mid_digits = flint_malloc(4);
-        if (arf_is_nan(arb_midref(x)))
+        if (arb_is_indeterminate(x))
             strcpy(*mid_digits, "nan");
         else
             strcpy(*mid_digits, "0");
@@ -439,7 +439,7 @@ char * arb_get_str(const arb_t x, slong n, ulong flags)
     {
         res = flint_malloc(10);
 
-        if (arf_is_nan(arb_midref(x)))
+        if (arb_is_indeterminate(x))
             strcpy(res, "nan");
         else
             strcpy(res, "[+/- inf]");

--- a/arb/intersection.c
+++ b/arb/intersection.c
@@ -17,7 +17,7 @@ arb_intersection(arb_t z, const arb_t x, const arb_t y, slong prec)
     arf_t left, right, t, xr, yr;
     int result;
 
-    if (arf_is_nan(arb_midref(x)) || arf_is_nan(arb_midref(y)))
+    if (arb_is_indeterminate(x) || arb_is_indeterminate(y))
     {
         arb_indeterminate(z);
         return 1;

--- a/arb/max.c
+++ b/arb/max.c
@@ -16,7 +16,7 @@ arb_max(arb_t z, const arb_t x, const arb_t y, slong prec)
 {
     arf_t left, right, t, xr, yr;
 
-    if (arf_is_nan(arb_midref(x)) || arf_is_nan(arb_midref(y)))
+    if (arb_is_indeterminate(x) || arb_is_indeterminate(y))
     {
         arb_indeterminate(z);
         return;

--- a/arb/min.c
+++ b/arb/min.c
@@ -16,7 +16,7 @@ arb_min(arb_t z, const arb_t x, const arb_t y, slong prec)
 {
     arf_t left, right, t, xr, yr;
 
-    if (arf_is_nan(arb_midref(x)) || arf_is_nan(arb_midref(y)))
+    if (arb_is_indeterminate(x) || arb_is_indeterminate(y))
     {
         arb_indeterminate(z);
         return;

--- a/arb/rel_error_bits.c
+++ b/arb/rel_error_bits.c
@@ -19,7 +19,7 @@ arb_rel_error_bits(const arb_t x)
 
     if (mag_is_zero(arb_radref(x)))
     {
-        if (arf_is_nan(arb_midref(x)))
+        if (arb_is_indeterminate(x))
             return ARF_PREC_EXACT;
         else
             return -ARF_PREC_EXACT;

--- a/arb/richcmp.c
+++ b/arb/richcmp.c
@@ -13,7 +13,7 @@
 
 int arb_eq(const arb_t x, const arb_t y)
 {
-    if (arf_is_nan(arb_midref(x)) || arf_is_nan(arb_midref(y)))
+    if (arb_is_indeterminate(x) || arb_is_indeterminate(y))
         return 0;
 
     if (mag_is_inf(arb_radref(x)) || mag_is_inf(arb_radref(y)))
@@ -28,7 +28,7 @@ int arb_eq(const arb_t x, const arb_t y)
 
 int arb_ne(const arb_t x, const arb_t y)
 {
-    if (arf_is_nan(arb_midref(x)) || arf_is_nan(arb_midref(y)))
+    if (arb_is_indeterminate(x) || arb_is_indeterminate(y))
         return 0;
 
     if (mag_is_inf(arb_radref(x)) || mag_is_inf(arb_radref(y)))
@@ -47,7 +47,7 @@ int arb_lt(const arb_t x, const arb_t y)
     arf_t t;
     int res;
 
-    if (arf_is_nan(arb_midref(x)) || arf_is_nan(arb_midref(y)))
+    if (arb_is_indeterminate(x) || arb_is_indeterminate(y))
         return 0;
 
     if (mag_is_inf(arb_radref(x)) || mag_is_inf(arb_radref(y)))
@@ -77,7 +77,7 @@ int arb_le(const arb_t x, const arb_t y)
     arf_t t;
     int res;
 
-    if (arf_is_nan(arb_midref(x)) || arf_is_nan(arb_midref(y)))
+    if (arb_is_indeterminate(x) || arb_is_indeterminate(y))
         return 0;
 
     if (mag_is_inf(arb_radref(x)) || mag_is_inf(arb_radref(y)))
@@ -108,7 +108,7 @@ int arb_gt(const arb_t x, const arb_t y)
     arf_t t;
     int res;
 
-    if (arf_is_nan(arb_midref(x)) || arf_is_nan(arb_midref(y)))
+    if (arb_is_indeterminate(x) || arb_is_indeterminate(y))
         return 0;
 
     if (mag_is_inf(arb_radref(x)) || mag_is_inf(arb_radref(y)))
@@ -138,7 +138,7 @@ int arb_ge(const arb_t x, const arb_t y)
     arf_t t;
     int res;
 
-    if (arf_is_nan(arb_midref(x)) || arf_is_nan(arb_midref(y)))
+    if (arb_is_indeterminate(x) || arb_is_indeterminate(y))
         return 0;
 
     if (mag_is_inf(arb_radref(x)) || mag_is_inf(arb_radref(y)))

--- a/arb/test/t-add_error.c
+++ b/arb/test/t-add_error.c
@@ -58,7 +58,7 @@ int main()
             arf_sub(arb_midref(b), arb_midref(b), r, ARF_PREC_EXACT, ARF_RND_DOWN);
 
         /* should this be done differently? */
-        if (arf_is_nan(arb_midref(b)))
+        if (arb_is_indeterminate(b))
             arf_zero(arb_midref(b));
 
         if (!arb_contains(c, b))
@@ -105,7 +105,7 @@ int main()
             arf_sub(arb_midref(b), arb_midref(b), m, ARF_PREC_EXACT, ARF_RND_DOWN);
 
         /* should this be done differently? */
-        if (arf_is_nan(arb_midref(b)))
+        if (arb_is_indeterminate(b))
             arf_zero(arb_midref(b));
 
         if (!arb_contains(c, b))
@@ -152,7 +152,7 @@ int main()
             arf_sub(arb_midref(b), arb_midref(b), t, ARF_PREC_EXACT, ARF_RND_DOWN);
 
         /* should this be done differently? */
-        if (arf_is_nan(arb_midref(b)))
+        if (arb_is_indeterminate(b))
             arf_zero(arb_midref(b));
 
         if (!arb_contains(c, b))
@@ -200,7 +200,7 @@ int main()
             arf_sub(arb_midref(b), arb_midref(b), t, ARF_PREC_EXACT, ARF_RND_DOWN);
 
         /* should this be done differently? */
-        if (arf_is_nan(arb_midref(b)))
+        if (arb_is_indeterminate(b))
             arf_zero(arb_midref(b));
 
         if (!arb_contains(c, b))
@@ -248,7 +248,7 @@ int main()
             arf_sub(arb_midref(b), arb_midref(b), t, ARF_PREC_EXACT, ARF_RND_DOWN);
 
         /* should this be done differently? */
-        if (arf_is_nan(arb_midref(b)))
+        if (arb_is_indeterminate(b))
             arf_zero(arb_midref(b));
 
         if (!arb_contains(c, b))

--- a/arb/test/t-get_mag.c
+++ b/arb/test/t-get_mag.c
@@ -33,7 +33,7 @@ int main()
         arb_get_mag(m, a);
         MAG_CHECK_BITS(m)
 
-        if (arf_is_nan(arb_midref(a)))
+        if (arb_is_indeterminate(a))
             arf_nan(arb_midref(b));
         else
             arf_zero(arb_midref(b));

--- a/arb/test/t-richcmp.c
+++ b/arb/test/t-richcmp.c
@@ -14,7 +14,7 @@
 static void
 arb_supremum(arf_t res, const arb_t x)
 {
-    if (arf_is_nan(arb_midref(x)))
+    if (arb_is_indeterminate(x))
     {
         arf_nan(res);
     }
@@ -32,7 +32,7 @@ arb_supremum(arf_t res, const arb_t x)
 static void
 arb_infimum(arf_t res, const arb_t x)
 {
-    if (arf_is_nan(arb_midref(x)))
+    if (arb_is_indeterminate(x))
     {
         arf_nan(res);
     }

--- a/arb/union.c
+++ b/arb/union.c
@@ -16,7 +16,7 @@ arb_union(arb_t z, const arb_t x, const arb_t y, slong prec)
 {
     arf_t left, right, t, xr, yr;
 
-    if (arf_is_nan(arb_midref(x)) || arf_is_nan(arb_midref(y)))
+    if (arb_is_indeterminate(x) || arb_is_indeterminate(y))
     {
         arb_indeterminate(z);
         return;

--- a/doc/source/arb.rst
+++ b/doc/source/arb.rst
@@ -494,6 +494,10 @@ Comparisons
     Returns nonzero iff the midpoint and radius of *x* are both finite
     floating-point numbers, i.e. not infinities or NaN.
 
+.. function:: int arb_is_indeterminate(const arb_t x)
+
+    Returns nonzero iff the midpoint of *x* is NaN.
+
 .. function:: int arb_is_exact(const arb_t x)
 
     Returns nonzero iff the radius of *x* is zero.


### PR DESCRIPTION
This PR would add a helper function `arb_is_indeterminate`. I'm not sure if it's named appropriately (should be `arb_is_nan`?) or if the idea is even sound.