### PR TITLE
Add Complex Versions of the falling factorials

### DIFF
--- a/acb.h
+++ b/acb.h
@@ -768,11 +768,104 @@ void acb_rising_ui_rec(acb_t y, const acb_t x, ulong n, slong prec);
 void acb_rising_ui(acb_t z, const acb_t x, ulong n, slong prec);
 void acb_rising(acb_t z, const acb_t x, const acb_t n, slong prec);
 
+ACB_INLINE void
+acb_falling_ui_bs(acb_t y, const acb_t x, ulong n, slong prec)
+{
+    acb_neg(y, x);
+    acb_rising_ui_bs(y, y, n, prec);
+
+    if (n % 2)
+        acb_neg(y, y);
+}
+
+ACB_INLINE void
+acb_falling_ui_rs(acb_t y, const acb_t x, ulong n, ulong m, slong prec)
+{
+    acb_neg(y, x);
+    acb_rising_ui_rs(y, y, n, m, prec);
+
+    if (n % 2)
+        acb_neg(y, y);
+}
+
+ACB_INLINE void
+acb_falling_ui_rec(acb_t y, const acb_t x, ulong n, slong prec)
+{
+    acb_neg(y, x);
+    acb_rising_ui_rec(y, y, n, prec);
+
+    if (n % 2)
+        acb_neg(y, y);
+}
+
+ACB_INLINE void
+acb_falling_ui(acb_t z, const acb_t x, ulong n, slong prec)
+{
+    acb_neg(z, x);
+    acb_rising_ui(z, z, n, prec);
+
+    if (n % 2)
+        acb_neg(z, z);    
+}
+
+void acb_falling(acb_t z, const acb_t x, const acb_t n, slong prec);
+
 void acb_rising2_ui_bs(acb_t u, acb_t v, const acb_t x, ulong n, slong prec);
 void acb_rising2_ui_rs(acb_t u, acb_t v, const acb_t x, ulong n, ulong m, slong prec);
 void acb_rising2_ui(acb_t u, acb_t v, const acb_t x, ulong n, slong prec);
 
+ACB_INLINE void
+acb_falling2_ui_bs(acb_t u, acb_t v, const acb_t x, ulong n, slong prec)
+{
+    acb_neg(v, x);
+    acb_rising2_ui_bs(u, v, v, n, prec);
+
+    if (n % 2)
+    {
+        acb_neg(u, u);
+        acb_neg(v, v);
+    }
+}
+
+ACB_INLINE void
+acb_falling2_ui_rs(acb_t u, acb_t v, const acb_t x, ulong n, ulong m, slong prec)
+{
+    acb_neg(v, x);
+    acb_rising2_ui_rs(u, v, v, n, m, prec);
+
+    if (n % 2)
+    {
+        acb_neg(u, u);
+        acb_neg(v, v);
+    }
+}
+
+ACB_INLINE void
+acb_falling2_ui(acb_t u, acb_t v, const acb_t x, ulong n, slong prec)
+{
+    acb_neg(v, x);
+    acb_rising2_ui(u, v, v, n, prec);
+
+    if (n % 2)
+    {
+        acb_neg(u, u);
+        acb_neg(v, v);
+    }
+}
+
 void acb_rising_ui_get_mag(mag_t bound, const acb_t s, ulong n);
+
+ACB_INLINE void
+acb_falling_ui_get_mag(mag_t bound, const acb_t s, ulong n)
+{
+    acb_t tmp;
+    acb_init(tmp);
+
+    acb_neg(tmp, s);
+    acb_rising_ui_get_mag(bound, tmp, n);
+
+    acb_clear(tmp);
+}
 
 void acb_gamma(acb_t y, const acb_t x, slong prec);
 void acb_rgamma(acb_t y, const acb_t x, slong prec);

--- a/acb/falling.c
+++ b/acb/falling.c
@@ -1,0 +1,36 @@
+/*
+    Copyright (C) 2014 Fredrik Johansson
+    Copyright (C) 2016 Ricky E. Farr
+
+    This file is part of Arb.
+
+    Arb is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "acb.h"
+
+void
+acb_falling(acb_t y, const acb_t x, const acb_t n, slong prec)
+{
+    if (acb_is_int(n) && arf_sgn(arb_midref(acb_realref(n))) >= 0 &&
+        arf_cmpabs_ui(arb_midref(acb_realref(n)), FLINT_MAX(prec, 100)) < 0)
+    {
+        acb_falling_ui_rec(y, x,
+            arf_get_si(arb_midref(acb_realref(n)), ARF_RND_DOWN), prec);
+    }
+    else
+    {
+        /* y = gamma(x + 1)/gamma(x - n + 1)  */
+        acb_t tmp;
+        acb_init(tmp);
+        acb_add_ui(tmp, x, 1, prec);
+        acb_gamma(y, tmp, prec);
+        acb_sub(tmp, tmp, n, prec);
+        acb_rgamma(tmp, tmp, prec);
+        acb_mul(y, y, tmp, prec);
+        acb_clear(tmp);
+    }
+}

--- a/doc/source/acb.rst
+++ b/doc/source/acb.rst
@@ -666,18 +666,18 @@ Rising and Falling factorials
     Whenever *n* is a small positive integer, the result is calculated
     using  :func:`acb_rising_ui_rec()`.
 
-.. function :: void acb_rising2_ui_bs(acb_t u, acb_t v, const acb_t x, ulong n, slong prec)
+.. function:: void acb_rising2_ui_bs(acb_t u, acb_t v, const acb_t x, ulong n, slong prec)
 
-.. function :: void acb_rising2_ui_rs(acb_t u, acb_t v, const acb_t x, ulong n, ulong step, slong prec)
+.. function:: void acb_rising2_ui_rs(acb_t u, acb_t v, const acb_t x, ulong n, ulong step, slong prec)
 
-.. function :: void acb_rising2_ui(acb_t u, acb_t v, const acb_t x, ulong n, slong prec)
+.. function:: void acb_rising2_ui(acb_t u, acb_t v, const acb_t x, ulong n, slong prec)
 
     Letting `u(x) = x (x+1) (x+2) \cdots (x+n-1)`, simultaneously compute
     `u(x)` and `v(x) = u'(x)`, respectively using binary splitting,
     rectangular splitting (with optional nonzero step length *step*
     to override the default choice), and an automatic algorithm choice.
 
-.. function :: void acb_rising_ui_get_mag(mag_t bound, const acb_t x, ulong n)
+.. function:: void acb_rising_ui_get_mag(mag_t bound, const acb_t x, ulong n)
 
     Computes an upper bound for the absolute value of
     the rising factorial `z = x (x+1) (x+2) \cdots (x+n-1)`.
@@ -691,13 +691,13 @@ Rising and Falling factorials
 
 .. function:: void acb_falling_ui(acb_t z, const acb_t x, ulong n, slong prec)
 
-.. function :: void acb_falling2_ui_bs(acb_t u, acb_t v, const acb_t x, ulong n, slong prec)
+.. function:: void acb_falling2_ui_bs(acb_t u, acb_t v, const acb_t x, ulong n, slong prec)
 
-.. function :: void acb_falling2_ui_rs(acb_t u, acb_t v, const acb_t x, ulong n, ulong step, slong prec)
+.. function:: void acb_falling2_ui_rs(acb_t u, acb_t v, const acb_t x, ulong n, ulong step, slong prec)
 
-.. function :: void acb_falling2_ui(acb_t u, acb_t v, const acb_t x, ulong n, slong prec)
+.. function:: void acb_falling2_ui(acb_t u, acb_t v, const acb_t x, ulong n, slong prec)
 
-.. function :: void acb_falling_ui_get_mag(mag_t bound, const acb_t x, ulong n)
+.. function:: void acb_falling_ui_get_mag(mag_t bound, const acb_t x, ulong n)
 
     Computes the falling factorial, `z = (x)_n = x (x-1) (x-2) \cdots (x-n+1)`, 
     using the identity, `z = (x)_n = (-1)^n (-x)^{(n)}`, and using the similarly

--- a/doc/source/acb.rst
+++ b/doc/source/acb.rst
@@ -634,7 +634,7 @@ Inverse hyperbolic functions
 
     Sets *res* to `\operatorname{atanh}(z) = -i \operatorname{atan}(iz)`.
 
-Rising factorials
+Rising and Falling factorials
 -------------------------------------------------------------------------------
 
 .. function:: void acb_rising_ui_bs(acb_t z, const acb_t x, ulong n, slong prec)
@@ -645,17 +645,26 @@ Rising factorials
 
 .. function:: void acb_rising_ui(acb_t z, const acb_t x, ulong n, slong prec)
 
-.. function:: void acb_rising(acb_t z, const acb_t x, const acb_t n, slong prec)
-
-    Computes the rising factorial `z = x (x+1) (x+2) \cdots (x+n-1)`.
+    Computes the rising factorial, `z = (x)^{(n)} = x (x+1) (x+2) \cdots (x+n-1)`.
 
     The *bs* version uses binary splitting. The *rs* version uses rectangular
-    splitting. The *rec* version uses either *bs* or *rs* depending
-    on the input. The default version uses the gamma function unless
+    splitting and takes an optional *step* parameter for tuning
+    purposes (to use the default step length, pass zero).
+
+    The *rec* version uses either *bs* or *rs* depending
+    on the input. The default version uses :func:`acb_rising()` unless
     *n* is a small integer.
 
-    The *rs* version takes an optional *step* parameter for tuning
-    purposes (to use the default step length, pass zero).
+.. function:: void acb_rising(acb_t z, const acb_t x, const acb_t n, slong prec)
+
+    Computes the rising factorial of *x* using the formula 
+
+    .. math ::
+
+        z = \frac{\Gamma(x + n)}{\Gamma(x)}.
+
+    Whenever *n* is a small positive integer, the result is calculated
+    using  :func:`acb_rising_ui_rec()`.
 
 .. function :: void acb_rising2_ui_bs(acb_t u, acb_t v, const acb_t x, ulong n, slong prec)
 
@@ -673,6 +682,37 @@ Rising factorials
     Computes an upper bound for the absolute value of
     the rising factorial `z = x (x+1) (x+2) \cdots (x+n-1)`.
     Not currently optimized for large *n*.
+
+.. function:: void acb_falling_ui_bs(acb_t z, const acb_t x, ulong n, slong prec)
+
+.. function:: void acb_falling_ui_rs(acb_t z, const acb_t x, ulong n, ulong step, slong prec)
+
+.. function:: void acb_falling_ui_rec(acb_t z, const acb_t x, ulong n, slong prec)
+
+.. function:: void acb_falling_ui(acb_t z, const acb_t x, ulong n, slong prec)
+
+.. function :: void acb_falling2_ui_bs(acb_t u, acb_t v, const acb_t x, ulong n, slong prec)
+
+.. function :: void acb_falling2_ui_rs(acb_t u, acb_t v, const acb_t x, ulong n, ulong step, slong prec)
+
+.. function :: void acb_falling2_ui(acb_t u, acb_t v, const acb_t x, ulong n, slong prec)
+
+.. function :: void acb_falling_ui_get_mag(mag_t bound, const acb_t x, ulong n)
+
+    Computes the falling factorial, `z = (x)_n = x (x-1) (x-2) \cdots (x-n+1)`, 
+    using the identity, `z = (x)_n = (-1)^n (-x)^{(n)}`, and using the similarly
+    defined *rising* factorial version of the function.
+
+.. function:: void acb_falling(acb_t z, const acb_t x, const acb_t n, slong prec)
+
+    Computes the falling factorial of *x* using the formula 
+
+    .. math ::
+
+        z = \frac{\Gamma(x + 1)}{\Gamma(x + n + 1)}.
+
+    Whenever *n* is a small positive integer, the result is calculated
+    using  :func:`acb_falling_ui_rec()`.
 
 Gamma function
 -------------------------------------------------------------------------------


### PR DESCRIPTION
In a later pull request, I'll add the arb version of the falling factorials.  Also, I'll add a falling version of acb_poly_rising_ui.

I didn't know if the functions should be inlined or not.  I'm assuming they should be since they are very short.  Then again, the clear functions were short too but eventually un-inlined.

I added a new file, falling.c, that includes only the function acb_falling.  It seems like acb_falling and acb_rising should be together in the same file...maybe factorial.c?
