### PR TITLE
Fix osx link issue in travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ script:
         export ARB_TEST_MULTIPLIER=0.1;
     fi
   - ./.build_dependencies
-  - ./configure --with-mpir=$HOME/deps --with-mpfr=$HOME/deps --with-flint=$HOME/deps
+  - ./configure --with-mpir=$HOME/deps --with-mpfr=$HOME/deps --with-flint=$HOME/deps --prefix=$HOME/deps
   - make -j4
+  - make install
   - make check
 


### PR DESCRIPTION
executables created in make check were looking for libarb in the
installation directory but libarb may not be installed yet.
As a workaround, arb is installed in travis-ci before make check
is run