### PR TITLE
Change abort to flint_abort only if flint > 2.5.2

### DIFF
--- a/arf.h
+++ b/arf.h
@@ -27,6 +27,12 @@
 #include "fmpr.h"
 #include "mag.h"
 
+#ifndef flint_abort
+#if __FLINT_RELEASE <= 20502
+#define flint_abort abort
+#endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/bool_mat.h
+++ b/bool_mat.h
@@ -22,6 +22,12 @@
 #include "flint/flint.h"
 #include "flint/fmpz_mat.h"
 
+#ifndef flint_abort
+#if __FLINT_RELEASE <= 20502
+#define flint_abort abort
+#endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/dlog.h
+++ b/dlog.h
@@ -18,6 +18,14 @@
 #define DLOG_INLINE static __inline__
 #endif
 
+#include "flint/flint.h"
+
+#ifndef flint_abort
+#if __FLINT_RELEASE <= 20502
+#define flint_abort abort
+#endif
+#endif
+
 #include "flint/ulong_extras.h"
 #include "flint/nmod_vec.h"
 

--- a/fmpr.h
+++ b/fmpr.h
@@ -25,6 +25,12 @@
 #include "flint/config.h"
 #include "fmpz_extras.h"
 
+#ifndef flint_abort
+#if __FLINT_RELEASE <= 20502
+#define flint_abort abort
+#endif
+#endif
+
 #define TLS_PREFIX FLINT_TLS_PREFIX
 
 #if defined(_MSC_VER) && defined(ARB_BUILD_DLL)

--- a/fmpz_extras.h
+++ b/fmpz_extras.h
@@ -20,6 +20,12 @@
 extern "C" {
 #endif
 
+#ifndef flint_abort
+#if __FLINT_RELEASE <= 20502
+#define flint_abort abort
+#endif
+#endif
+
 /* currently defined in the arb module, but global to the library */
 double arb_test_multiplier(void);
 

--- a/mag.h
+++ b/mag.h
@@ -24,6 +24,12 @@
 #include "flint/fmpz.h"
 #include "fmpz_extras.h"
 
+#ifndef flint_abort
+#if __FLINT_RELEASE <= 20502
+#define flint_abort abort
+#endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Since there is no global header file (or I could not find it), these checks are scattered all over the place.