### PR TITLE
fix test for 32 bits

### DIFF
--- a/dirichlet/group_init.c
+++ b/dirichlet/group_init.c
@@ -98,8 +98,8 @@ dirichlet_group_lift_generators(dirichlet_group_t G)
                 G->P[k].g, G->P[k].pe.n, G->q, G->P[k].e);
         }
         v = nmod_inv(qpe % pe.n, pe);
-        /* no overflow since v * qpe < q */
-        G->generators[k] = (1 + (G->P[k].g-1) * v * qpe) % G->q;
+        /* v * qpe < q */
+        G->generators[k] = (1 + nmod_mul(G->P[k].g-1, v * qpe, G->mod)) % G->q;
     }
 }
 

--- a/dirichlet/test/t-properties.c
+++ b/dirichlet/test/t-properties.c
@@ -110,7 +110,9 @@ int main()
                 }
 
                 /* lift to higher modulus */
-                q2 = q * (1 + n_randint(state, 100));
+                do {
+                    q2 = q * (1 + n_randint(state, 100));
+                } while (q2 % q); /* in case of overflow */
 
                 dirichlet_group_init(G2, q2);
                 dirichlet_char_init(chi2, G2);
@@ -140,23 +142,29 @@ int main()
                     flint_abort();
                 }
 
+                /* choose q3 s.t. conductor | q3 | q */
                 q3 = dirichlet_conductor_char(G, chi) * random_divisor(state, G);
                 q3 = n_gcd(q, q3);
 
-                dirichlet_group_init(G3, q3);
-                dirichlet_char_init(chi3, G3);
-                dirichlet_char_lower(chi3, G3, chi2, G2);
+                /* discard if overflow */
+                if (q3 % p1 == 0)
+                {
+                    dirichlet_group_init(G3, q3);
+                    dirichlet_char_init(chi3, G3);
+                    dirichlet_char_lower(chi3, G3, chi2, G2);
 
-                p1 = dirichlet_conductor_char(G, chi);
-                p2 = dirichlet_conductor_char(G3, chi3);
-                check_eq(p1, p2, q, m, "conductor chi", "conductor lower");
+                    p1 = dirichlet_conductor_char(G, chi);
+                    p2 = dirichlet_conductor_char(G3, chi3);
+                    check_eq(p1, p2, q, m, "conductor chi", "conductor lower");
 
-                p1 = dirichlet_order_char(G, chi);
-                p2 = dirichlet_order_char(G3, chi3);
-                check_eq(p1, p2, q, m, "order chi", "order lower");
+                    p1 = dirichlet_order_char(G, chi);
+                    p2 = dirichlet_order_char(G3, chi3);
+                    check_eq(p1, p2, q, m, "order chi", "order lower");
 
-                dirichlet_char_clear(chi3);
-                dirichlet_group_clear(G3);
+                    dirichlet_char_clear(chi3);
+                    dirichlet_group_clear(G3);
+                }
+
                 dirichlet_char_clear(chi2);
                 dirichlet_group_clear(G2);
 


### PR DESCRIPTION
The bug was caused by overflows in the test file.

This commit also makes lift_generators stronger (there was a possible overflow in case of a large generator).