### PR TITLE
install static library in LIBDIR instead of lib

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -171,7 +171,7 @@ install: library
 		cp -a $(shell ls $(ARB_LIBNAME)*) "$(DESTDIR)$(PREFIX)/$(LIBDIR)"; \
 	fi
 	$(AT)if [ "$(ARB_STATIC)" -eq "1" ]; then \
-		cp libarb.a $(DESTDIR)$(PREFIX)/lib; \
+		cp libarb.a $(DESTDIR)$(PREFIX)/$(LIBDIR); \
 	fi
 	cp $(HEADERS) $(DESTDIR)$(PREFIX)/include
 	$(AT)if [ ! -z $(EXT_HEADERS) ]; then \


### PR DESCRIPTION
Currently `Makefile.in` installs static libraries in `$(DESTDIR)/$(PREFIX)/lib` instead of `$(DESTDIR)/$(PREFIX)/$(LIBDIR)` as the dynamic one. This can have funny consequence since `$(DESTDIR)/$(PREFIX)/$(LIBDIR)` is created by the install target but `$(DESTDIR)/$(PREFIX)/lib` isn't. `/usr/lib` usually exist on unix but when `DESTDIR` is set all your bets are off. As seen in https://github.com/cschwan/sage-on-gentoo/issues/471 the side effects are interesting.