### PR TITLE
xi and zeta near zero

### DIFF
--- a/acb_dirichlet/xi.c
+++ b/acb_dirichlet/xi.c
@@ -52,7 +52,8 @@ void acb_dirichlet_xi(acb_t res, const acb_t s, slong prec)
         acb_one(res);
         acb_mul_2exp_si(res, res, -1);
     }
-    else if (arf_sgn(arb_midref(acb_realref(s))) < 0 ||
+    else if ((arf_sgn(arb_midref(acb_realref(s))) < 0 &&
+        !acb_contains_zero(s)) ||
         (arb_contains_si(acb_realref(s), 1) && /* also intervals around s = 1 */
         arb_contains_zero(acb_imagref(s))))
     {

--- a/acb_dirichlet/zeta.c
+++ b/acb_dirichlet/zeta.c
@@ -52,7 +52,8 @@ acb_dirichlet_zeta(acb_t res, const acb_t s, slong prec)
         return;
     }
 
-    if (arf_sgn(arb_midref(acb_realref(s))) < 0)
+    if ((arf_sgn(arb_midref(acb_realref(s))) < 0) &&
+        !acb_contains_zero(s))
     {
         acb_t t, u, v;
         slong wp = prec + 6;


### PR DESCRIPTION
Applying the functional equation to xi and zeta when s includes zero and has its midpoint in the left half plane causes infinite error bounds.