### PR TITLE
tests for platt lemma bounds

### DIFF
--- a/acb_dirichlet/platt_c_bound.c
+++ b/acb_dirichlet/platt_c_bound.c
@@ -28,7 +28,7 @@ _gamma_upper_workaround(arb_t res, const arb_t s, const arb_t z,
         arb_init(x);
         for (i = 0; i < 5; i++)
         {
-            arb_hypgeom_gamma_upper(x, s, z, regularized, prec * (1 << i));
+            arb_hypgeom_gamma_upper(x, s, z, regularized, prec << i);
             if (arb_rel_accuracy_bits(x) > 1)
             {
                 break;

--- a/acb_dirichlet/platt_lemma_A11.c
+++ b/acb_dirichlet/platt_lemma_A11.c
@@ -28,7 +28,7 @@ _gamma_upper_workaround(arb_t res, const arb_t s, const arb_t z,
         arb_init(x);
         for (i = 0; i < 5; i++)
         {
-            arb_hypgeom_gamma_upper(x, s, z, regularized, prec * (1 << i));
+            arb_hypgeom_gamma_upper(x, s, z, regularized, prec << i);
             if (arb_rel_accuracy_bits(x) > 1)
             {
                 break;

--- a/acb_dirichlet/platt_lemma_A5.c
+++ b/acb_dirichlet/platt_lemma_A5.c
@@ -29,7 +29,7 @@ _gamma_upper_workaround(arb_t res, const arb_t s, const arb_t z,
         arb_init(x);
         for (i = 0; i < 5; i++)
         {
-            arb_hypgeom_gamma_upper(x, s, z, regularized, prec * (1 << i));
+            arb_hypgeom_gamma_upper(x, s, z, regularized, prec << i);
             if (arb_rel_accuracy_bits(x) > 1)
             {
                 break;

--- a/acb_dirichlet/platt_ws_interpolation.c
+++ b/acb_dirichlet/platt_ws_interpolation.c
@@ -28,7 +28,7 @@ _gamma_upper_workaround(arb_t res, const arb_t s, const arb_t z,
         arb_init(x);
         for (i = 0; i < 5; i++)
         {
-            arb_hypgeom_gamma_upper(x, s, z, regularized, prec * (1 << i));
+            arb_hypgeom_gamma_upper(x, s, z, regularized, prec << i);
             if (arb_rel_accuracy_bits(x) > 1)
             {
                 break;


### PR DESCRIPTION
This PR adds regression tests for each of the eight lemma bounds that are involved in the error calculations for the Platt multieval function. To help prevent or detect typos in the implementations, the values hardcoded in the tests were computed with PARI/GP code independent from arb. The tests do not verify the inequalities of the bounds themselves so typos in the primary literature wouldn't be detected.

The plan for the next PR is to add a low level `zeta_zeros`-like function that takes about a dozen tuning parameters and that isolates zeros within a single fft region, maybe on the order of a thousand zeros. If the tuning parameters are well chosen then it should be significantly faster than the existing zeta zeros implementation but if the tuning parameters are poorly chosen then the function will be slow or won't isolate many zeros. I'm planning to use the Lehman and Arias de Reyna variant of Turing's method rather than the Booker variant.

After this, I was thinking of there could be two development tracks. One track would provide a wrapper function that automatically picks the dozen or so tuning parameter values, and a second wrapper function would call the first wrapper function repeatedly until the requested number of zeros is met; this high level function (maybe `platt_zeta_zeros`) would have the same interface as the current `zeta_zeros` function. Maybe `zeta_zeros` could call the `platt_zeta_zeros` function when appropriate.

The second development track would be for large scale numerical RH verification if there is enough interest, probably using the low level zeta zeros function and choosing/updating the tuning parameters itself and controlling the number of calls made to the low level function. Maybe some functions supporting this use case would be in scope for arb, or maybe this entire track should be done as a separate downstream project.