### PR TITLE
gitignore automake/libtool artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ libarb.so*
 libarb.a
 doc/build/*
 *.ppm
+*.lo
+*.deps/
+*.libs/
+*.dirstamp


### PR DESCRIPTION
arb does not use automake but a project might pull in arb as a submodule
and build parts of it with automake