### PR TITLE
fix doc typo

### DIFF
--- a/doc/source/arb_hypgeom.rst
+++ b/doc/source/arb_hypgeom.rst
@@ -445,7 +445,7 @@ Orthogonal polynomials and functions
 Dilogarithm
 -------------------------------------------------------------------------------
 
-.. function:: void arb_hypgeom_dilog(arb_t res, const arb_t z slong prec)
+.. function:: void arb_hypgeom_dilog(arb_t res, const arb_t z, slong prec)
 
     Computes the dilogarithm `\operatorname{Li}_2(z)`.
 


### PR DESCRIPTION
Trying to do some automatic parsing of the documentation in relation to [Arblib.jl](https://github.com/kalmarek/Arblib.jl) I ran into this parsing error.