### PR TITLE
Remove long

### DIFF
--- a/acb.h
+++ b/acb.h
@@ -996,7 +996,7 @@ acb_printd(const acb_t z, slong digits)
     acb_fprintd(stdout, z, digits);
 }
 
-void acb_fprintn(FILE * fp, const acb_t z, long digits, ulong flags);
+void acb_fprintn(FILE * fp, const acb_t z, slong digits, ulong flags);
 
 ACB_INLINE void
 acb_printn(const acb_t x, slong digits, ulong flags)

--- a/acb/fprintn.c
+++ b/acb/fprintn.c
@@ -13,7 +13,7 @@
 #include "acb.h"
 
 void
-acb_fprintn(FILE * file, const acb_t z, long digits, ulong flags)
+acb_fprintn(FILE * file, const acb_t z, slong digits, ulong flags)
 {
     if (arb_is_zero(acb_imagref(z)))
     {

--- a/arb.h
+++ b/arb.h
@@ -294,8 +294,8 @@ arb_get_rad_arb(arb_t z, const arb_t x)
 
 void arb_get_abs_ubound_arf(arf_t u, const arb_t x, slong prec);
 void arb_get_abs_lbound_arf(arf_t u, const arb_t x, slong prec);
-void arb_get_ubound_arf(arf_t u, const arb_t x, long prec);
-void arb_get_lbound_arf(arf_t u, const arb_t x, long prec);
+void arb_get_ubound_arf(arf_t u, const arb_t x, slong prec);
+void arb_get_lbound_arf(arf_t u, const arb_t x, slong prec);
 
 void arb_nonnegative_part(arb_t res, const arb_t x);
 

--- a/arb/get_lbound_arf.c
+++ b/arb/get_lbound_arf.c
@@ -12,7 +12,7 @@
 #include "arb.h"
 
 void
-arb_get_lbound_arf(arf_t u, const arb_t x, long prec)
+arb_get_lbound_arf(arf_t u, const arb_t x, slong prec)
 {
     arf_t t;
     arf_init_set_mag_shallow(t, arb_radref(x));

--- a/arb/get_ubound_arf.c
+++ b/arb/get_ubound_arf.c
@@ -12,7 +12,7 @@
 #include "arb.h"
 
 void
-arb_get_ubound_arf(arf_t u, const arb_t x, long prec)
+arb_get_ubound_arf(arf_t u, const arb_t x, slong prec)
 {
     arf_t t;
     arf_init_set_mag_shallow(t, arb_radref(x));

--- a/doc/source/arb.rst
+++ b/doc/source/arb.rst
@@ -419,12 +419,12 @@ Radius and interval operations
     Sets *u* to the lower bound for the absolute value of *x*,
     rounded down to *prec* bits. If *x* contains NaN, the result is NaN.
 
-.. function:: void arb_get_ubound_arf(arf_t u, const arb_t x, long prec)
+.. function:: void arb_get_ubound_arf(arf_t u, const arb_t x, slong prec)
 
     Sets *u* to the upper bound for the value of *x*,
     rounded up to *prec* bits. If *x* contains NaN, the result is NaN.
 
-.. function:: void arb_get_lbound_arf(arf_t u, const arb_t x, long prec)
+.. function:: void arb_get_lbound_arf(arf_t u, const arb_t x, slong prec)
 
     Sets *u* to the lower bound for the value of *x*,
     rounded down to *prec* bits. If *x* contains NaN, the result is NaN.

--- a/partitions/hrr_sum_arb.c
+++ b/partitions/hrr_sum_arb.c
@@ -90,7 +90,7 @@ bound_primes(ulong k)
 }
 
 
-static __inline__ long
+static __inline__ slong
 log2_ceil(double x)
 {
     /* ceil(log2(n)) = bitcount(n-1);


### PR DESCRIPTION
In general arb uses `slong` for 64 bits signed integers, in a few places `long` was used instead. I believe all of these cases are just typos and this pull request fixes those. There seems to be no other occurrences as determined by `grep -R " long"` (notice the space before `long`). 