### PR TITLE
add fransen robinson constant as an integral example

### DIFF
--- a/examples/integrals.c
+++ b/examples/integrals.c
@@ -583,6 +583,18 @@ f_rsqrt(acb_ptr res, const acb_t z, void * param, slong order, slong prec)
     return 0;
 }
 
+/* f(z) = rgamma(z) */
+int
+f_rgamma(acb_ptr res, const acb_t z, void * param, slong order, slong prec)
+{
+    if (order > 1)
+        flint_abort();  /* Would be needed for Taylor method. */
+
+    acb_rgamma(res, z, prec);
+
+    return 0;
+}
+
 /* f(z) = exp(-z^2+iz) */
 int
 f_gaussian_twist(acb_ptr res, const acb_t z, void * param, slong order, slong prec)
@@ -721,7 +733,7 @@ scaled_bessel_select_N(arb_t N, ulong k, slong prec)
 /*  Main test program                                                        */
 /* ------------------------------------------------------------------------- */
 
-#define NUM_INTEGRALS 36
+#define NUM_INTEGRALS 37
 
 const char * descr[NUM_INTEGRALS] =
 {
@@ -761,6 +773,7 @@ const char * descr[NUM_INTEGRALS] =
     "int_0^{inf} exp(-x) I_0(x/3)^3 dx   (using domain truncation)",
     "int_0^{inf} exp(-x) I_0(x/15)^{15} dx   (using domain truncation)",
     "int_{-1-i}^{-1+i} 1/sqrt(x) dx",
+    "int_0^{inf} 1/gamma(x) dx   (using domain truncation)",
 };
 
 int main(int argc, char *argv[])
@@ -1236,6 +1249,14 @@ int main(int argc, char *argv[])
                 acb_set_d_d(a, -1, -1);
                 acb_set_d_d(b, -1, 1);
                 acb_calc_integrate(s, f_rsqrt, NULL, a, b, goal, tol, options, prec);
+
+            case 36:
+                if (goal < 0)
+                    abort();
+                acb_zero(a);
+                acb_set_ui(b, 4 + (goal + 1) / 2);
+                acb_calc_integrate(s, f_rgamma, NULL, a, b, goal, tol, options, prec);
+                arb_add_error_2exp_si(acb_realref(s), -goal);
                 break;
 
             default:


### PR DESCRIPTION
While looking at integrals of gamma-related functions with the hope of improving the incomplete gamma function implementation for zeta zeros parameter tuning I noticed this constant on Wikipedia so I've tried adding it as an integral example. Later I saw on its oeis entry that you've already written this code lol, but I thought I'd submit this pr anyway.