### PR TITLE
improve upper incomplete gamma algorithm selection for nonnegative real s and z

### DIFF
--- a/acb_dirichlet/platt_c_bound.c
+++ b/acb_dirichlet/platt_c_bound.c
@@ -12,33 +12,6 @@
 #include "acb_dirichlet.h"
 #include "arb_hypgeom.h"
 
-/* Increase precision adaptively. */
-static void
-_gamma_upper_workaround(arb_t res, const arb_t s, const arb_t z,
-        int regularized, slong prec)
-{
-    if (!arb_is_finite(s) || !arb_is_finite(z))
-    {
-        arb_indeterminate(res);
-    }
-    else
-    {
-        arb_t x;
-        slong i;
-        arb_init(x);
-        for (i = 0; i < 5; i++)
-        {
-            arb_hypgeom_gamma_upper(x, s, z, regularized, prec << i);
-            if (arb_rel_accuracy_bits(x) > 1)
-            {
-                break;
-            }
-        }
-        arb_swap(res, x);
-        arb_clear(x);
-    }
-}
-
 static void
 _arb_pow_si(arb_t res, const arb_t x, slong y, slong prec)
 {
@@ -175,7 +148,7 @@ _pre_c_p(arb_ptr res, slong sigma, const arb_t h, ulong k, slong prec)
 
         arb_set_si(x, k + l + 1);
         arb_mul_2exp_si(x, x, -1);
-        _gamma_upper_workaround(x, x, u, 0, prec);
+        arb_hypgeom_gamma_upper(x, x, u, 0, prec);
         arb_mul(res + l, res + l, x, prec);
     }
 

--- a/acb_dirichlet/platt_lemma_A11.c
+++ b/acb_dirichlet/platt_lemma_A11.c
@@ -12,33 +12,6 @@
 #include "acb_dirichlet.h"
 #include "arb_hypgeom.h"
 
-/* Increase precision adaptively. */
-static void
-_gamma_upper_workaround(arb_t res, const arb_t s, const arb_t z,
-        int regularized, slong prec)
-{
-    if (!arb_is_finite(s) || !arb_is_finite(z))
-    {
-        arb_indeterminate(res);
-    }
-    else
-    {
-        arb_t x;
-        slong i;
-        arb_init(x);
-        for (i = 0; i < 5; i++)
-        {
-            arb_hypgeom_gamma_upper(x, s, z, regularized, prec << i);
-            if (arb_rel_accuracy_bits(x) > 1)
-            {
-                break;
-            }
-        }
-        arb_swap(res, x);
-        arb_clear(x);
-    }
-}
-
 static void
 _platt_lemma_A11_X(arb_t out,
         const arb_t t0, const arb_t h, slong B, const arb_t beta, slong prec)
@@ -90,7 +63,7 @@ _platt_lemma_A11_Y(arb_t out,
     arb_sqr(x4, x4, prec);
     arb_mul_2exp_si(x4, x4, -3);
 
-    _gamma_upper_workaround(x5, x3, x4, 0, prec);
+    arb_hypgeom_gamma_upper(x5, x3, x4, 0, prec);
 
     arb_mul(out, x1, x2, prec);
     arb_mul(out, out, x5, prec);
@@ -131,7 +104,7 @@ _platt_lemma_A11_Z(arb_t out,
     arb_sqr(x4, x4, prec);
     arb_mul_2exp_si(x4, x4, -1);
 
-    _gamma_upper_workaround(x5, x3, x4, 0, prec);
+    arb_hypgeom_gamma_upper(x5, x3, x4, 0, prec);
 
     arb_mul(out, x1, x2, prec);
     arb_mul(out, out, x5, prec);

--- a/acb_dirichlet/platt_lemma_A5.c
+++ b/acb_dirichlet/platt_lemma_A5.c
@@ -12,34 +12,6 @@
 #include "acb_dirichlet.h"
 #include "arb_hypgeom.h"
 
-
-/* Increase precision adaptively. */
-static void
-_gamma_upper_workaround(arb_t res, const arb_t s, const arb_t z,
-        int regularized, slong prec)
-{
-    if (!arb_is_finite(s) || !arb_is_finite(z))
-    {
-        arb_indeterminate(res);
-    }
-    else
-    {
-        arb_t x;
-        slong i;
-        arb_init(x);
-        for (i = 0; i < 5; i++)
-        {
-            arb_hypgeom_gamma_upper(x, s, z, regularized, prec << i);
-            if (arb_rel_accuracy_bits(x) > 1)
-            {
-                break;
-            }
-        }
-        arb_swap(res, x);
-        arb_clear(x);
-    }
-}
-
 /* Lemma A5 requires B > h*sqrt(k) */
 static int
 _platt_lemma_A5_constraint(slong B, const arb_t h, slong k, slong prec)
@@ -106,7 +78,7 @@ acb_dirichlet_platt_lemma_A5(arb_t out, slong B, const arb_t h,
 
     arb_mul_2exp_si(x6, b, -1);
 
-    _gamma_upper_workaround(x6, x6, a, 0, prec);
+    arb_hypgeom_gamma_upper(x6, x6, a, 0, prec);
 
     arb_mul(out, x4, x5, prec);
     arb_mul(out, out, x6, prec);

--- a/acb_dirichlet/platt_ws_interpolation.c
+++ b/acb_dirichlet/platt_ws_interpolation.c
@@ -13,33 +13,6 @@
 #include "arb_hypgeom.h"
 #include "arb_poly.h"
 
-/* Increase precision adaptively. */
-static void
-_gamma_upper_workaround(arb_t res, const arb_t s, const arb_t z,
-        int regularized, slong prec)
-{
-    if (!arb_is_finite(s) || !arb_is_finite(z))
-    {
-        arb_indeterminate(res);
-    }
-    else
-    {
-        arb_t x;
-        slong i;
-        arb_init(x);
-        for (i = 0; i < 5; i++)
-        {
-            arb_hypgeom_gamma_upper(x, s, z, regularized, prec << i);
-            if (arb_rel_accuracy_bits(x) > 1)
-            {
-                break;
-            }
-        }
-        arb_swap(res, x);
-        arb_clear(x);
-    }
-}
-
 static void
 _arb_div_si_si(arb_t res, slong x, slong y, slong prec)
 {
@@ -218,7 +191,7 @@ _platt_bound_C3_Y(arb_t res, const arb_t t0, slong A, const arb_t H,
     arb_div(g2, g2, H, prec);
     arb_sqr(g2, g2, prec);
     arb_mul_2exp_si(g2, g2, -1);
-    _gamma_upper_workaround(g, g1, g2, 0, prec);
+    arb_hypgeom_gamma_upper(g, g1, g2, 0, prec);
 
     /* res = a*b*A*H*g */
     arb_mul_si(res, H, A, prec);
@@ -261,7 +234,7 @@ _platt_bound_C3_Z(arb_t res, const arb_t t0, slong A, const arb_t H,
     arb_div(g2, t0, H, prec);
     arb_sqr(g2, g2, prec);
     arb_mul_2exp_si(g2, g2, -1);
-    _gamma_upper_workaround(g, g1, g2, 0, prec);
+    arb_hypgeom_gamma_upper(g, g1, g2, 0, prec);
 
     /* res = a*b*A*g */
     arb_mul_si(res, g, A, prec);

--- a/acb_hypgeom/gamma_upper.c
+++ b/acb_hypgeom/gamma_upper.c
@@ -388,15 +388,7 @@ acb_hypgeom_gamma_upper(acb_t res, const acb_t s, const acb_t z, int regularized
             return;
         }
 
-        if (0 < n && n < WORD_MAX)
-        {
-            if (acb_hypgeom_u_use_asymp(z, prec))
-            {
-                acb_hypgeom_gamma_upper_asymp(res, s, z, regularized, prec);
-                return;
-            }
-        }
-        else if (_acb_is_nonnegative_real(s) && _acb_is_nonnegative_real(z))
+        if (_acb_is_nonnegative_real(s) && _acb_is_nonnegative_real(z))
         {
             if (arf_cmpabs_2exp_si(arb_midref(acb_realref(z)), 2) > 0)
             {
@@ -413,13 +405,11 @@ acb_hypgeom_gamma_upper(acb_t res, const acb_t s, const acb_t z, int regularized
                 }
             }
         }
-        else if (_determine_region(s, z))
+        else if (acb_hypgeom_u_use_asymp(z, prec) &&
+                 ((0 < n && n < WORD_MAX) || _determine_region(s, z)))
         {
-            if (acb_hypgeom_u_use_asymp(z, prec))
-            {
-                acb_hypgeom_gamma_upper_asymp(res, s, z, regularized, prec);
-                return;
-            }
+            acb_hypgeom_gamma_upper_asymp(res, s, z, regularized, prec);
+            return;
         }
 
         if (n <= 0 && n > -10 * prec)

--- a/acb_hypgeom/gamma_upper.c
+++ b/acb_hypgeom/gamma_upper.c
@@ -398,7 +398,9 @@ acb_hypgeom_gamma_upper(acb_t res, const acb_t s, const acb_t z, int regularized
                 c = 2.391097143;
                 ds = arf_get_d(arb_midref(acb_realref(s)), ARF_RND_DOWN);
                 dx = arf_get_d(arb_midref(acb_realref(z)), ARF_RND_DOWN);
-                if (pow(dx - c, 8) > pow(a*ds, 8) + pow(b*prec, 8))
+                if (dx - c > a*ds + b*prec ||
+                    (dx - c > FLINT_MAX(a*ds, b*prec) &&
+                    pow(dx - c, 8) > pow(a*ds, 8) + pow(b*prec, 8)))
                 {
                     acb_hypgeom_gamma_upper_asymp(res, s, z, regularized, prec);
                     return;

--- a/acb_hypgeom/gamma_upper.c
+++ b/acb_hypgeom/gamma_upper.c
@@ -283,62 +283,49 @@ _determine_region(const acb_t s, const acb_t z)
     return R;
 }
 
-/* Compares x = a^n to y = b^n + c^n as computed with mag_t arithmetic.
- * Returns negative, zero, or positive, depending on whether x is smaller,
- * equal, or larger than y.
+/* Returns 1 if it can be determined that a^n > b^n + c^n.
  * Requires 1 <= n <= WORD_MAX.
  * If n == WORD_MAX, the infinity norm a > max(b, c) is compared instead. */
 int
-_mag_cmp_norm_ui(const mag_t a, const mag_t b, const mag_t c, ulong n)
+_mag_gt_norm_ui(const mag_t a, const mag_t b, const mag_t c, ulong n)
 {
-    int result, a0, b0, c0;
+    int result;
     result = 0;
-    a0 = mag_is_zero(a);
-    b0 = mag_is_zero(b);
-    c0 = mag_is_zero(c);
     if (n < 1)
     {
         flint_abort();
     }
-    else if (a0 && b0 && c0)
+    else if (mag_is_zero(a))
     {
         result = 0;
     }
-    else if (a0)
+    else if (mag_is_zero(b))
     {
-        result = -1;
+        result = mag_cmp(a, c) > 0;
     }
-    else if (b0 && c0)
+    else if (mag_is_zero(c))
     {
-        result = 1;
-    }
-    else if (b0)
-    {
-        result = mag_cmp(a, c);
-    }
-    else if (c0)
-    {
-        result = mag_cmp(a, b);
+        result = mag_cmp(a, b) > 0;
     }
     else if (n == WORD_MAX)
     {
-        result = FLINT_MIN(mag_cmp(a, b), mag_cmp(a, c));
+        result = mag_cmp(a, b) > 0 && mag_cmp(a, c) > 0;
     }
     else if (n == 1)
     {
         mag_t sum;
         mag_init(sum);
         mag_add(sum, b, c);
-        result = mag_cmp(a, sum);
+        result = mag_cmp(a, sum) > 0;
         mag_clear(sum);
     }
-    else if (_mag_cmp_norm_ui(a, b, c, 1) >= 0)
+    else if (_mag_gt_norm_ui(a, b, c, 1))
     {
         result = 1;
     }
-    else if (_mag_cmp_norm_ui(a, b, c, WORD_MAX) <= 0)
+    else if (!_mag_gt_norm_ui(a, b, c, WORD_MAX))
     {
-        result = -1;
+        result = 0;
     }
     else
     {
@@ -347,11 +334,11 @@ _mag_cmp_norm_ui(const mag_t a, const mag_t b, const mag_t c, ulong n)
         mag_init(v);
         mag_init(w);
         mag_init(sum);
-        mag_pow_ui(u, a, n);
+        mag_pow_ui_lower(u, a, n);
         mag_pow_ui(v, b, n);
         mag_pow_ui(w, c, n);
         mag_add(sum, v, w);
-        result = mag_cmp(u, sum);
+        result = mag_cmp(u, sum) > 0;
         mag_clear(u);
         mag_clear(v);
         mag_clear(w);
@@ -363,7 +350,8 @@ _mag_cmp_norm_ui(const mag_t a, const mag_t b, const mag_t c, ulong n)
 /* Given nonnegative real s, x, and prec,
  * returns 1 if the asymptotic expansion of the
  * hypergeometric U function should be used for upper incomplete gamma.
- * It returns 1 if x > 4 and (x-c)^8 > (a*s)^8 + (b*prec)^8. */
+ * It returns 1 if x > 4 and (x-c)^8 > (a*s)^8 + (b*prec)^8.
+ * Careful mag rounding is not used because this is just a heuristic. */
 static int
 _nonnegative_real_use_asymp(const mag_t s, const mag_t x, slong prec)
 {
@@ -384,7 +372,7 @@ _nonnegative_real_use_asymp(const mag_t s, const mag_t x, slong prec)
         mag_sub(u, x, c);
         mag_mul(v, a, s);
         mag_mul_ui(w, b, FLINT_MAX(0, prec));
-        result = _mag_cmp_norm_ui(u, v, w, 8) > 0;
+        result = _mag_gt_norm_ui(u, v, w, 8);
         mag_clear(a);
         mag_clear(b);
         mag_clear(c);

--- a/acb_hypgeom/test/t-gamma_upper.c
+++ b/acb_hypgeom/test/t-gamma_upper.c
@@ -11,6 +11,28 @@
 
 #include "acb_hypgeom.h"
 
+
+static void
+_accuracy_regression_test(const acb_t s, const acb_t z,
+        int regularized, slong prec, slong issue, slong accuracy)
+{
+    acb_t g;
+    acb_init(g);
+    acb_hypgeom_gamma_upper(g, s, z, regularized, prec);
+    if (acb_rel_accuracy_bits(g) < accuracy)
+    {
+        flint_printf("FAIL: accuracy regression in issue #%ld\n\n", issue);
+        flint_printf("prec = %d\n\n", prec);
+        flint_printf("regularized = %d\n\n", regularized);
+        flint_printf("s = "); acb_printd(s, 30); flint_printf("\n\n");
+        flint_printf("z = "); acb_printd(z, 30); flint_printf("\n\n");
+        flint_printf("g = "); acb_printd(g, 30); flint_printf("\n\n");
+        flint_abort();
+    }
+    acb_clear(g);
+}
+
+
 int main()
 {
     slong iter;
@@ -209,6 +231,40 @@ int main()
         acb_clear(w1);
         acb_clear(t);
         acb_clear(u);
+    }
+
+    /* Accuracy regression tests. */
+    {
+        acb_t s, z;
+        slong prec, issue, accuracy;
+        acb_init(s);
+        acb_init(z);
+
+        issue = 166;
+        prec = 165;
+        accuracy = 100;
+        acb_zero(s);
+        acb_set_si(z, 110);
+        _accuracy_regression_test(s, z, 2, prec, issue, accuracy);
+
+        issue = 276;
+        prec = 300;
+        accuracy = 100;
+        acb_set_ui(s, 357);
+        acb_set_ui(z, 356);
+        _accuracy_regression_test(s, z, 0, prec, issue, accuracy);
+        arb_set_str(acb_realref(s), "356.123", prec);
+        arb_set_str(acb_realref(z), "356.456", prec);
+        _accuracy_regression_test(s, z, 0, prec, issue, accuracy);
+        arb_set_str(acb_realref(s), "357.123", prec);
+        arb_set_str(acb_realref(z), "356.456", prec);
+        _accuracy_regression_test(s, z, 0, prec, issue, accuracy);
+        arb_set_str(acb_realref(s), "357.456", prec);
+        arb_set_str(acb_realref(z), "356.123", prec);
+        _accuracy_regression_test(s, z, 0, prec, issue, accuracy);
+
+        acb_clear(s);
+        acb_clear(z);
     }
 
     flint_randclear(state);


### PR DESCRIPTION
When s and z are nonnegative real, the asymptotic expansion is used when `(z-c)^8 > (a*s)^8 + (b*prec)^8` where `a=1.029287542, b=0.3319411658, c=2.391097143`. For reference the `acb_hypgeom_u_use_asymp` condition has `a=0, b=0.69314718055994530942, c=0` in this notation.

Closes https://github.com/fredrik-johansson/arb/issues/276.
Closes https://github.com/fredrik-johansson/arb/issues/166.

The [magic constants](https://en.wikipedia.org/wiki/Magic_number_(programming)) were found by locating the best transition point for each point in the grid prec=16..400 s=0.5..200.5 then contour plotting the results, guessing a nonlinear model, and fitting the constants. The mean squared error for the predicted x transition point as a function of s and prec is about 1. The model looks solid enough to me that extrapolating beyond the training grid seems OK.

Machine floats are used for speed, and I'm not sure if overflow would be a problem. This PR only deals with nonnegative real s and z, so there are still algorithm selection problems when s and z have imaginary parts. I'm not totally sure what's going on with integer values of s. Surprisingly I haven't noticed any actual transition region issues, in other words I haven't noticed a point where neither the 1f1 nor the asymp algorithms were good enough, but I haven't looked for this specifically.