### PR TITLE
Platt multieval threaded

### DIFF
--- a/acb_dirichlet.h
+++ b/acb_dirichlet.h
@@ -285,8 +285,10 @@ void acb_dirichlet_platt_lemma_B2(arb_t out, slong K, const arb_t h,
 
 /* Platt DFT grid evaluation of scaled Lambda */
 
-void acb_dirichlet_platt_multieval(arb_ptr out, const fmpz_t T, slong A,
-    slong B, const arb_t h, slong J, slong K, slong sigma, slong prec);
+void acb_dirichlet_platt_multieval(arb_ptr out, const fmpz_t T,
+    slong A, slong B, const arb_t h, slong J, slong K, slong sigma, slong prec);
+void acb_dirichlet_platt_multieval_threaded(arb_ptr out, const fmpz_t T,
+    slong A, slong B, const arb_t h, slong J, slong K, slong sigma, slong prec);
 
 /* Platt Hardy Z zeros */
 

--- a/acb_dirichlet/platt_multieval.c
+++ b/acb_dirichlet/platt_multieval.c
@@ -469,17 +469,26 @@ void
 acb_dirichlet_platt_multieval(arb_ptr out, const fmpz_t T, slong A, slong B,
         const arb_t h, slong J, slong K, slong sigma, slong prec)
 {
-    slong N = A*B;
-    acb_ptr S;
-    arb_t t0;
+    if (flint_get_num_threads() > 1 && J > 10000000)
+    {
+        acb_dirichlet_platt_multieval_threaded(
+                out, T, A, B, h, J, K, sigma, prec);
+    }
+    else
+    {
+        slong N = A*B;
+        acb_ptr S;
+        arb_t t0;
 
-    arb_init(t0);
-    S =  _acb_vec_init(K*N);
+        arb_init(t0);
+        S =  _acb_vec_init(K*N);
 
-    arb_set_fmpz(t0, T);
-    _platt_smk(S, t0, A, B, 1, J, K, prec);
-    _acb_dirichlet_platt_multieval(out, S, t0, A, B, h, J, K, sigma, prec);
+        arb_set_fmpz(t0, T);
+        _platt_smk(S, t0, A, B, 1, J, K, prec);
+        _acb_dirichlet_platt_multieval(out, S, t0, A, B, h, J, K, sigma, prec);
 
-    arb_clear(t0);
-    _acb_vec_clear(S, K*N);
+        arb_clear(t0);
+        _acb_vec_clear(S, K*N);
+    }
 }
+

--- a/acb_dirichlet/platt_multieval_threaded.c
+++ b/acb_dirichlet/platt_multieval_threaded.c
@@ -1,0 +1,100 @@
+/*
+    Copyright (C) 2020 Rudolph
+    Copyright (C) 2020 D.H.J. Polymath
+
+    This file is part of Arb.
+
+    Arb is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "acb_dirichlet.h"
+#include "pthread.h"
+
+void _platt_smk(acb_ptr table, const arb_t t0, slong A, slong B,
+        slong Jstart, slong Jstop, slong K, slong prec);
+
+void _acb_dirichlet_platt_multieval(arb_ptr out, acb_srcptr S_table,
+        const arb_t t0, slong A, slong B, const arb_t h, slong J,
+        slong K, slong sigma, slong prec);
+
+typedef struct
+{
+    acb_ptr threadtable;
+    arb_srcptr t0;
+    slong A;
+    slong B;
+    slong K;
+    slong start;
+    slong stop;
+    slong prec;
+}
+platt_smk_arg_t;
+
+static void *
+_platt_smk_thread(void * arg_ptr)
+{
+    platt_smk_arg_t *p = (platt_smk_arg_t *) arg_ptr;
+    _platt_smk(p->threadtable, p->t0, p->A, p->B,
+               p->start, p->stop, p->K, p->prec);
+    flint_cleanup();
+    return NULL;
+}
+
+void
+acb_dirichlet_platt_multieval_threaded(arb_ptr out, const fmpz_t T, slong A,
+        slong B, const arb_t h, slong J, slong K, slong sigma, slong prec)
+{
+    slong i, num_threads, N, threadtasks;
+    pthread_t * threads;
+    platt_smk_arg_t * args;
+    acb_ptr S;
+    arb_t t0;
+
+    N = A*B;
+    num_threads = flint_get_num_threads();
+    threads = flint_malloc(sizeof(pthread_t) * num_threads);
+    args = flint_malloc(sizeof(platt_smk_arg_t) * num_threads);
+    threadtasks = (J+num_threads-1)/num_threads;
+
+    arb_init(t0);
+    arb_set_fmpz(t0, T);
+
+    S =  _acb_vec_init(K*N);
+    for (i = 0; i < num_threads; i++)
+    {
+        args[i].threadtable = _acb_vec_init(K*N);
+        args[i].t0 = t0;
+        args[i].A = A;
+        args[i].B = B;
+        args[i].K = K;
+        args[i].start = i*threadtasks + 1;
+        args[i].stop = (i+1)*threadtasks;;
+        args[i].prec = prec;
+    }
+    args[num_threads-1].stop = J;
+
+    for (i = 0; i < num_threads; i++)
+    {
+        pthread_create(&threads[i], NULL, _platt_smk_thread, &args[i]);
+    }
+
+    for (i = 0; i < num_threads; i++)
+    {
+        pthread_join(threads[i], NULL);
+    }
+
+    _acb_vec_zero(S, K*N);
+    for (i = 0; i < num_threads; i++)
+    {
+        _acb_vec_add(S, S, args[i].threadtable, K*N, prec);
+        _acb_vec_clear(args[i].threadtable, K*N);
+    }
+
+    _acb_dirichlet_platt_multieval(out, S, t0, A, B, h, J, K, sigma, prec);
+
+    arb_clear(t0);
+    _acb_vec_clear(S, K*N);
+}

--- a/acb_dirichlet/test/t-platt_multieval_threaded.c
+++ b/acb_dirichlet/test/t-platt_multieval_threaded.c
@@ -1,0 +1,155 @@
+/*
+    Copyright (C) 2020 D.H.J. Polymath
+
+    This file is part of Arb.
+
+    Arb is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "acb_dirichlet.h"
+
+static void
+_arb_div_si_si(arb_t res, slong a, slong b, slong prec)
+{
+    arb_set_si(res, a);
+    arb_div_si(res, res, b, prec);
+}
+
+static int
+_arb_vec_overlaps(arb_srcptr a, arb_srcptr b, slong len)
+{
+    slong i;
+    for (i = 0; i < len; i++)
+    {
+        if (!arb_overlaps(a + i, b + i))
+        {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+int main()
+{
+    slong iter;
+    flint_rand_t state;
+
+    flint_printf("platt_multieval_threaded....");
+    fflush(stdout);
+    flint_randinit(state);
+
+    /* Check a specific combination of parameter values that is relatively fast
+     * to evaluate and that has relatively tight bounds. */
+    {
+        slong A = 8;
+        slong B = 128;
+        slong N = A*B;
+        slong J = 1000;
+        slong K = 30;
+        slong sigma = 63;
+        slong prec = 128;
+        fmpz_t T;
+        arb_t h;
+        arb_ptr vec;
+
+        arb_init(h);
+        fmpz_init(T);
+
+        fmpz_set_si(T, 10000);
+        arb_set_d(h, 4.5);
+
+        flint_set_num_threads(5);
+
+        /* Check a few random entries in the multieval vector. */
+        vec = _arb_vec_init(N);
+        acb_dirichlet_platt_multieval_threaded(vec, T, A, B, h, J, K, sigma, prec);
+        for (iter = 0; iter < 20; iter++)
+        {
+            arb_t t, r;
+            slong i = n_randint(state, N);
+            slong n = i - N/2;
+            arb_init(t);
+            arb_init(r);
+            _arb_div_si_si(t, n, A, prec);
+            arb_add_fmpz(t, t, T, prec);
+            acb_dirichlet_platt_scaled_lambda(r, t, prec);
+            if (!arb_overlaps(vec + i, r))
+            {
+                flint_printf("FAIL: overlap for hardcoded example\n\n");
+                flint_printf("i = %wd  n = %wd\n\n", i, n);
+                flint_printf("vec[%wd] = ", i); arb_printn(vec + i, 30, 0); flint_printf("\n\n");
+                flint_printf("r = "); arb_printn(r, 30, 0); flint_printf("\n\n");
+                flint_abort();
+            }
+            arb_clear(t);
+            arb_clear(r);
+        }
+
+        fmpz_clear(T);
+        arb_clear(h);
+        _arb_vec_clear(vec, N);
+    }
+
+    for (iter = 0; iter < 10 * arb_test_multiplier(); iter++)
+    {
+        slong prec;
+        ulong A, B, N, J, K;
+        slong sigma, Tbits;
+        fmpz_t T;
+        arb_t h;
+        arb_ptr v1, v2;
+
+        /* better but slower limits are in parentheses below */
+        prec = 2 + n_randint(state, 300);
+        sigma = 1 + 2*(1 + n_randint(state, 100)); /* (200) */
+        J = 1 + n_randint(state, 100); /* (10000) */
+        K = 1 + n_randint(state, 20); /* (50) */
+        A = 1 + n_randint(state, 10);
+        B = 1 + n_randint(state, 10); /* (500) */
+        if (n_randint(state, 2))
+            A *= 2;
+        else
+            B *= 2;
+        N = A*B;
+
+        fmpz_init(T);
+        Tbits = 5 + n_randint(state, 15);
+        fmpz_set_ui(T, n_randtest_bits(state, Tbits));
+
+        arb_init(h);
+        arb_set_si(h, 1 + n_randint(state, 20000));
+        arb_div_si(h, h, 1000, prec);
+
+        flint_set_num_threads(1 + n_randint(state, 5));
+
+        v1 = _arb_vec_init(N);
+        v2 = _arb_vec_init(N);
+        acb_dirichlet_platt_scaled_lambda_vec(v1, T, A, B, prec);
+        acb_dirichlet_platt_multieval_threaded(v2, T, A, B, h, J, K, sigma, prec);
+
+        if (!_arb_vec_overlaps(v1, v2, N))
+        {
+            flint_printf("FAIL: overlap\n\n");
+            flint_printf("iter = %wd  prec = %wd\n\n", iter, prec);
+            flint_printf("sigma = %wd\n\n", sigma);
+            flint_printf("A = %wu  B = %wu  J = %wu  K = %wu\n\n", A, B, J, K);
+            flint_printf("T = "); fmpz_print(T); flint_printf("\n\n");
+            flint_printf("h = "); arb_printn(h, 30, 0); flint_printf("\n\n");
+            flint_abort();
+        }
+
+        arb_clear(h);
+        fmpz_clear(T);
+        _arb_vec_clear(v1, N);
+        _arb_vec_clear(v2, N);
+    }
+
+    flint_randclear(state);
+    flint_cleanup();
+    flint_printf("PASS\n");
+    return EXIT_SUCCESS;
+}
+

--- a/doc/source/acb_dirichlet.rst
+++ b/doc/source/acb_dirichlet.rst
@@ -758,13 +758,18 @@ and formulas described by David J. Platt in [Pla2017]_.
 
 .. function:: void acb_dirichlet_platt_multieval(arb_ptr res, const fmpz_t T, slong A, slong B, const arb_t h, slong J, slong K, slong sigma, slong prec)
 
+.. function:: void acb_dirichlet_platt_multieval_threaded(arb_ptr res, const fmpz_t T, slong A, slong B, const arb_t h, slong J, slong K, slong sigma, slong prec)
+
     Compute :func:`acb_dirichlet_platt_scaled_lambda` at `N=AB` points on a
     grid, following the notation of [Pla2017]_. The first point on the grid
     is `T - B/2` and the distance between grid points is `1/A`. The product
-    `N=AB` must be an even integer. The multieval variant evaluates the
-    function at all points on the grid simultaneously using forward and inverse
-    discrete Fourier transforms, and it requires the four additional tuning
-    parameters *h*, *J*, *K*, and *sigma*.
+    `N=AB` must be an even integer. The multieval versions evaluate the
+    function at all points on the grid simultaneously using discrete Fourier
+    transforms, and they require the four additional tuning parameters
+    *h*, *J*, *K*, and *sigma*. The *threaded* multieval version splits the
+    computation over the number of threads returned by
+    *flint_get_num_threads()*, while the default multieval version chooses
+    whether to use multithreading automatically.
 
 .. function:: void acb_dirichlet_platt_ws_interpolation(arb_t res, arf_t deriv, const arb_t t0, arb_srcptr p, const fmpz_t T, slong A, slong B, slong Ns_max, const arb_t H, slong sigma, slong prec)
 


### PR DESCRIPTION
Add a multithreaded version of a grid evaluation function for computing zeta zeros. It's based on Rudolph's code in https://github.com/fredrik-johansson/arb/issues/320 and on the threading ideas in the multithreaded matrix multiplication.