### PR TITLE
add radix2 dft multi-threading

### DIFF
--- a/acb_dft.h
+++ b/acb_dft.h
@@ -34,6 +34,8 @@ void acb_dft_rad2(acb_ptr w, acb_srcptr v, int e, slong prec);
 void acb_dft_bluestein(acb_ptr w, acb_srcptr v, slong len, slong prec);
 void acb_dft_prod(acb_ptr w, acb_srcptr v, slong * cyc, slong num, slong prec);
 
+void acb_dft_rad2_inplace_threaded(acb_ptr v, int e, slong prec);
+
 void acb_dft_convol_naive(acb_ptr w, acb_srcptr f, acb_srcptr g, slong len, slong prec);
 void acb_dft_convol_dft(acb_ptr w, acb_srcptr f, acb_srcptr g, slong len, slong prec);
 void acb_dft_convol_rad2(acb_ptr w, acb_srcptr f, acb_srcptr g, slong len, slong prec);
@@ -188,6 +190,8 @@ void acb_dft_rad2_precomp(acb_ptr w, acb_srcptr v, const acb_dft_rad2_t rad2, sl
 void acb_dft_crt_precomp(acb_ptr w, acb_srcptr v, const acb_dft_crt_t crt, slong prec);
 void acb_dft_prod_precomp(acb_ptr w, acb_srcptr v, const acb_dft_prod_t prod, slong prec);
 void acb_dft_bluestein_precomp(acb_ptr w, acb_srcptr v, const acb_dft_bluestein_t t, slong prec);
+
+void acb_dft_rad2_precomp_inplace_threaded(acb_ptr v, const acb_dft_rad2_t rad2, slong prec);
 
 void acb_dft_inverse_rad2_precomp_inplace(acb_ptr v, const acb_dft_rad2_t rad2, slong prec);
 void acb_dft_inverse_rad2_precomp(acb_ptr w, acb_srcptr v, const acb_dft_rad2_t rad2, slong prec);

--- a/acb_dft/rad2.c
+++ b/acb_dft/rad2.c
@@ -57,24 +57,31 @@ _acb_dft_rad2_init(acb_dft_rad2_t t, slong dv, int e, slong prec)
 void
 acb_dft_rad2_precomp_inplace(acb_ptr v, const acb_dft_rad2_t rad2, slong prec)
 {
-    slong j, k, l;
-    slong n = rad2->n, nz = rad2->nz;
-    acb_ptr p, vend = v + n, w = rad2->z;
-    acb_t tmp;
-    acb_init(tmp);
+    if (flint_get_num_threads() > 1 && rad2-> e > 9)
+    {
+        acb_dft_rad2_precomp_inplace_threaded(v, rad2, prec);
+    }
+    else
+    {
+        slong j, k, l;
+        slong n = rad2->n, nz = rad2->nz;
+        acb_ptr p, vend = v + n, w = rad2->z;
+        acb_t tmp;
+        acb_init(tmp);
 
-    acb_dft_rad2_reorder(v, n);
+        acb_dft_rad2_reorder(v, n);
 
-    for (k = 1, l = nz; k < n; k <<= 1, l >>= 1)
-        for (p = v; p < vend; p += k)
-            for (j = 0; j < nz; j += l, p++)
-            {
-                acb_mul(tmp, p + k, w + j, prec);
-                acb_sub(p + k, p + 0, tmp, prec);
-                acb_add(p + 0, p + 0, tmp, prec);
-            }
+        for (k = 1, l = nz; k < n; k <<= 1, l >>= 1)
+            for (p = v; p < vend; p += k)
+                for (j = 0; j < nz; j += l, p++)
+                {
+                    acb_mul(tmp, p + k, w + j, prec);
+                    acb_sub(p + k, p + 0, tmp, prec);
+                    acb_add(p + 0, p + 0, tmp, prec);
+                }
 
-    acb_clear(tmp);
+        acb_clear(tmp);
+    }
 }
 
 void

--- a/acb_dft/rad2_threaded.c
+++ b/acb_dft/rad2_threaded.c
@@ -1,0 +1,125 @@
+/*
+    Copyright (C) 2016 Pascal Molin
+    Copyright (C) 2020 D.H.J. Polymath
+
+    This file is part of Arb.
+
+    Arb is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "acb_dft.h"
+#include "pthread.h"
+
+void acb_dft_rad2_reorder(acb_ptr v, slong n);
+
+typedef struct
+{
+    acb_ptr v;
+    acb_ptr vend;
+    slong k;
+    slong l;
+    slong jstart;
+    slong jend;
+    acb_srcptr w;
+    slong prec;
+}
+acb_dft_rad2_arg_t;
+
+void *
+_acb_dft_rad2_thread(void * arg_ptr)
+{
+    acb_dft_rad2_arg_t arg = *((acb_dft_rad2_arg_t *) arg_ptr);
+    slong j, rstart, pstep;
+    acb_ptr p, r;
+    acb_t tmp;
+
+    acb_init(tmp);
+    rstart = arg.jstart / arg.l;
+    pstep = 2 * arg.k;
+
+    for (p = arg.v; p < arg.vend; p += pstep)
+    {
+        for (r = p + rstart, j = arg.jstart; j < arg.jend; j += arg.l, r++)
+        {
+            acb_mul(tmp, r + arg.k, arg.w + j, arg.prec);
+            acb_sub(r + arg.k, r + 0, tmp, arg.prec);
+            acb_add(r + 0, r + 0, tmp, arg.prec);
+        }
+    }
+
+    acb_clear(tmp);
+    flint_cleanup();
+    return NULL;
+}
+
+void
+acb_dft_rad2_precomp_inplace_threaded(acb_ptr v, const acb_dft_rad2_t rad2, slong prec)
+{
+    slong num_threads;
+    pthread_t * threads;
+    acb_dft_rad2_arg_t * args;
+
+    slong t, logt, logk, logl;
+    slong n = rad2->n;
+    slong nz = rad2->nz; /* always n/2 ? */
+    slong logn = rad2->e;
+
+    num_threads = FLINT_MIN(flint_get_num_threads(), nz);
+    for (logt = 0; WORD(1) << (logt + 1) <= num_threads; logt++);
+    t = WORD(1) << logt;
+
+    threads = flint_malloc(sizeof(pthread_t) * t);
+    args = flint_malloc(sizeof(acb_dft_rad2_arg_t) * t);
+
+    acb_dft_rad2_reorder(v, n);
+
+    for (logk = 0, logl = logn - 1; logk < logn; logk += 1, logl -= 1)
+    {
+        slong i, j, p;
+        slong logpstep = logk + 1 + FLINT_MAX(0, logl - logt);
+        slong logjstep = logl + FLINT_MIN(logk, logn - 1 - logt);
+        slong pstep = WORD(1) << logpstep;
+        slong jstep = WORD(1) << logjstep;
+        i = 0;
+        for (p = 0; p < n; p += pstep)
+        {
+            for (j = 0; j < nz ; j += jstep)
+            {
+                args[i].v = v + p;
+                args[i].vend = v + p + pstep;
+                args[i].jstart = j;
+                args[i].jend = j + jstep;
+                args[i].k = WORD(1) << logk;
+                args[i].l = WORD(1) << logl;
+                args[i].w = rad2->z;
+                args[i].prec = prec;
+                pthread_create(&threads[i], NULL, _acb_dft_rad2_thread, &args[i]);
+                i++;
+            }
+        }
+        if (i != t)
+        {
+            flint_printf("threaded dft error: unequal i=%ld t=%ld\n", i, t);
+            flint_abort();
+        }
+        for (i = 0; i < t; i++)
+        {
+            pthread_join(threads[i], NULL);
+        }
+    }
+
+    flint_free(threads);
+    flint_free(args);
+}
+
+void
+acb_dft_rad2_inplace_threaded(acb_ptr v, int e, slong prec)
+{
+    acb_dft_rad2_t rad2;
+    acb_dft_rad2_init(rad2, e, prec);
+    acb_dft_rad2_precomp_inplace_threaded(v, rad2, prec);
+    acb_dft_rad2_clear(rad2);
+}

--- a/acb_dft/test/t-dft.c
+++ b/acb_dft/test/t-dft.c
@@ -150,6 +150,29 @@ int main()
 
     }
 
+    /* multi-threaded radix2 dft */
+    for (k = 0; k < 11; k++)
+    {
+        slong n = 1 << k, j;
+        acb_ptr v, w1, w2;
+        v = w2 = _acb_vec_init(n);
+        w1 = _acb_vec_init(n);
+
+        flint_set_num_threads(k % 5 + 1);
+
+        for (j = 0; j < n; j++)
+            acb_set_si_si(v + j, j, j + 2);
+
+        acb_dft_cyc(w1, v, n, prec);
+        acb_dft_rad2_inplace_threaded(w2, k, prec);
+
+        check_vec_eq_prec(w1, w2, n, prec, digits, n, "rad2", "cyc", "rad2");
+
+        _acb_vec_clear(v, n);
+        _acb_vec_clear(w1, n);
+
+    }
+
     flint_randclear(state);
     flint_cleanup();
     flint_printf("PASS\n");


### PR DESCRIPTION
This PR adds radix 2 dft multi-threading. It's slower for small vectors and faster for large vectors, so I've hardcoded a threshold where multi-threading will only be used implicitly when the vector length is greater than 2^9.

The dft consists of three nested loops. The outer serial loop does log2(n) iterations and is not parallelized at all. The two nested inner loops consist of 2^a and 2^b iterations respectively for each combination of a and b where a+b+1= log2(n), and they can be jointly parallelized to spread the work evenly among threads. I used the threaded matrix multiplication code as the example of how to do multi-threading with the pthreads library.

I see that @pascalmolin wrote a lot of the dft stuff in arb, maybe if I did something dumb in this PR he would notice.

Here's some output of a modified version of https://github.com/fredrik-johansson/arb/blob/master/acb_dft/profile/p-dft.c, 'default' is single threaded rad2, 'thread4' is rad2 with four threads, and 'precomp' is single threaded rad2 with setup/teardown (including calculation of roots of unity) pulled out of the timing repetition loop.

```
1280 * DFT(256 = 2^8), prec 64....
default        ...  cpu/wall(s): 0.367 0.367

thread4        ...  cpu/wall(s): 1.037 0.499

precomp        ...  cpu/wall(s): 0.355 0.354

640 * DFT(512 = 2^9), prec 64....
default        ...  cpu/wall(s): 0.413 0.413

thread4        ...  cpu/wall(s): 0.876 0.372

precomp        ...  cpu/wall(s): 0.405 0.404

320 * DFT(1024 = 2^10), prec 64....
default        ...  cpu/wall(s): 0.457 0.456

thread4        ...  cpu/wall(s): 0.738 0.277

precomp        ...  cpu/wall(s): 0.456 0.457

160 * DFT(2048 = 2^11), prec 64....
default        ...  cpu/wall(s): 0.527 0.528

thread4        ...  cpu/wall(s): 0.705 0.249

precomp        ...  cpu/wall(s): 0.514 0.513

80 * DFT(4096 = 2^12), prec 64....
default        ...  cpu/wall(s): 0.586 0.586

thread4        ...  cpu/wall(s): 0.7 0.218

precomp        ...  cpu/wall(s): 0.563 0.564

40 * DFT(8192 = 2^13), prec 64....
default        ...  cpu/wall(s): 0.628 0.631

thread4        ...  cpu/wall(s): 0.702 0.205

precomp        ...  cpu/wall(s): 0.607 0.607

640 * DFT(256 = 2^8), prec 128....
default        ...  cpu/wall(s): 0.233 0.233

thread4        ...  cpu/wall(s): 0.604 0.29

precomp        ...  cpu/wall(s): 0.225 0.226

320 * DFT(512 = 2^9), prec 128....
default        ...  cpu/wall(s): 0.278 0.278

thread4        ...  cpu/wall(s): 0.518 0.219

precomp        ...  cpu/wall(s): 0.272 0.272

160 * DFT(1024 = 2^10), prec 128....
default        ...  cpu/wall(s): 0.301 0.302

thread4        ...  cpu/wall(s): 0.46 0.178

precomp        ...  cpu/wall(s): 0.293 0.294

80 * DFT(2048 = 2^11), prec 128....
default        ...  cpu/wall(s): 0.334 0.334

thread4        ...  cpu/wall(s): 0.431 0.142

precomp        ...  cpu/wall(s): 0.322 0.322

40 * DFT(4096 = 2^12), prec 128....
default        ...  cpu/wall(s): 0.363 0.363

thread4        ...  cpu/wall(s): 0.444 0.144

precomp        ...  cpu/wall(s): 0.363 0.363

20 * DFT(8192 = 2^13), prec 128....
default        ...  cpu/wall(s): 0.398 0.398

thread4        ...  cpu/wall(s): 0.48 0.152

precomp        ...  cpu/wall(s): 0.427 0.426

160 * DFT(256 = 2^8), prec 512....
default        ...  cpu/wall(s): 0.112 0.112

thread4        ...  cpu/wall(s): 0.232 0.101

precomp        ...  cpu/wall(s): 0.098 0.098

80 * DFT(512 = 2^9), prec 512....
default        ...  cpu/wall(s): 0.122 0.122

thread4        ...  cpu/wall(s): 0.208 0.099

precomp        ...  cpu/wall(s): 0.116 0.116

40 * DFT(1024 = 2^10), prec 512....
default        ...  cpu/wall(s): 0.134 0.134

thread4        ...  cpu/wall(s): 0.182 0.072

precomp        ...  cpu/wall(s): 0.122 0.122

20 * DFT(2048 = 2^11), prec 512....
default        ...  cpu/wall(s): 0.143 0.143

thread4        ...  cpu/wall(s): 0.205 0.068

precomp        ...  cpu/wall(s): 0.139 0.139

10 * DFT(4096 = 2^12), prec 512....
default        ...  cpu/wall(s): 0.157 0.157

thread4        ...  cpu/wall(s): 0.214 0.076

precomp        ...  cpu/wall(s): 0.154 0.155

5 * DFT(8192 = 2^13), prec 512....
default        ...  cpu/wall(s): 0.175 0.175

thread4        ...  cpu/wall(s): 0.207 0.065

precomp        ...  cpu/wall(s): 0.163 0.163

64 * DFT(256 = 2^8), prec 1024....
default        ...  cpu/wall(s): 0.066 0.066

thread4        ...  cpu/wall(s): 0.128 0.051

precomp        ...  cpu/wall(s): 0.064 0.065

32 * DFT(512 = 2^9), prec 1024....
default        ...  cpu/wall(s): 0.075 0.074

thread4        ...  cpu/wall(s): 0.12 0.044

precomp        ...  cpu/wall(s): 0.072 0.071

16 * DFT(1024 = 2^10), prec 1024....
default        ...  cpu/wall(s): 0.086 0.086

thread4        ...  cpu/wall(s): 0.122 0.04

precomp        ...  cpu/wall(s): 0.082 0.082

8 * DFT(2048 = 2^11), prec 1024....
default        ...  cpu/wall(s): 0.092 0.092

thread4        ...  cpu/wall(s): 0.134 0.046

precomp        ...  cpu/wall(s): 0.092 0.092

4 * DFT(4096 = 2^12), prec 1024....
default        ...  cpu/wall(s): 0.103 0.103

thread4        ...  cpu/wall(s): 0.145 0.048

precomp        ...  cpu/wall(s): 0.103 0.104

2 * DFT(8192 = 2^13), prec 1024....
default        ...  cpu/wall(s): 0.119 0.119

thread4        ...  cpu/wall(s): 0.151 0.048

precomp        ...  cpu/wall(s): 0.116 0.116


```