### PR TITLE
use fmpz instead of slong for the J parameter of windowed zeta zeros

### DIFF
--- a/acb_dirichlet.h
+++ b/acb_dirichlet.h
@@ -280,23 +280,25 @@ void acb_dirichlet_platt_lemma_A9(arb_t out, slong sigma, const arb_t t0,
 void acb_dirichlet_platt_lemma_A11(arb_t out, const arb_t t0, const arb_t h,
     slong B, slong prec);
 void acb_dirichlet_platt_lemma_B1(arb_t out, slong sigma, const arb_t t0,
-    const arb_t h, slong J, slong prec);
+    const arb_t h, const fmpz_t J, slong prec);
 void acb_dirichlet_platt_lemma_B2(arb_t out, slong K, const arb_t h,
     const arb_t xi, slong prec);
 
 /* Platt DFT grid evaluation of scaled Lambda */
 
 void acb_dirichlet_platt_multieval(arb_ptr out, const fmpz_t T,
-    slong A, slong B, const arb_t h, slong J, slong K, slong sigma, slong prec);
+    slong A, slong B, const arb_t h, const fmpz_t J, slong K,
+    slong sigma, slong prec);
 void acb_dirichlet_platt_multieval_threaded(arb_ptr out, const fmpz_t T,
-    slong A, slong B, const arb_t h, slong J, slong K, slong sigma, slong prec);
+    slong A, slong B, const arb_t h, const fmpz_t J, slong K,
+    slong sigma, slong prec);
 
 /* Platt Hardy Z zeros */
 
 slong _acb_dirichlet_platt_local_hardy_z_zeros(
     arb_ptr res, const fmpz_t n, slong len,
     const fmpz_t T, slong A, slong B,
-    const arb_t h, slong J, slong K, slong sigma_grid,
+    const arb_t h, const fmpz_t J, slong K, slong sigma_grid,
     slong Ns_max, const arb_t H, slong sigma_interp, slong prec);
 slong acb_dirichlet_platt_local_hardy_z_zeros(
     arb_ptr res, const fmpz_t n, slong len, slong prec);

--- a/acb_dirichlet/platt_lemma_B1.c
+++ b/acb_dirichlet/platt_lemma_B1.c
@@ -11,22 +11,11 @@
 
 #include "acb_dirichlet.h"
 
-static void
-_arb_ui_pow_arb(arb_t res, ulong n, const arb_t x, slong prec)
-{
-    arb_t a;
-    arb_init(a);
-    arb_set_ui(a, n);
-    arb_pow(res, a, x, prec);
-    arb_clear(a);
-}
-
 void
 acb_dirichlet_platt_lemma_B1(arb_t out,
-        slong sigma, const arb_t t0, const arb_t h, slong J, slong prec)
+        slong sigma, const arb_t t0, const arb_t h, const fmpz_t J, slong prec)
 {
-    arb_t pi, C;
-    arb_t x1, x2, x3;
+    arb_t pi, C, x1, x2, x3, Ja;
 
     if (sigma % 2 == 0 || sigma < 3)
     {
@@ -39,9 +28,11 @@ acb_dirichlet_platt_lemma_B1(arb_t out,
     arb_init(x1);
     arb_init(x2);
     arb_init(x3);
+    arb_init(Ja);
 
     arb_const_pi(pi, prec);
     acb_dirichlet_platt_c_bound(C, sigma, t0, h, 0, prec);
+    arb_set_fmpz(Ja, J);
 
     arb_set_si(x1, 2*sigma - 1);
     arb_div(x1, x1, h, prec);
@@ -54,7 +45,7 @@ acb_dirichlet_platt_lemma_B1(arb_t out,
     arb_pow(x2, pi, x2, prec);
 
     arb_set_si(x3, 1 - sigma);
-    _arb_ui_pow_arb(x3, (ulong) J, x3, prec);
+    arb_pow(x3, Ja, x3, prec);
     arb_div_si(x3, x3, sigma - 1, prec);
 
     arb_mul(out, x1, x2, prec);
@@ -66,4 +57,5 @@ acb_dirichlet_platt_lemma_B1(arb_t out,
     arb_clear(x1);
     arb_clear(x2);
     arb_clear(x3);
+    arb_clear(Ja);
 }

--- a/acb_dirichlet/platt_local_hardy_z_zeros.c
+++ b/acb_dirichlet/platt_local_hardy_z_zeros.c
@@ -55,7 +55,7 @@ typedef const platt_ctx_struct * platt_ctx_srcptr;
 static void
 platt_ctx_init(platt_ctx_t ctx,
         const fmpz_t T, slong A, slong B,
-        const arb_t h, slong J, slong K, slong sigma_grid,
+        const arb_t h, const fmpz_t J, slong K, slong sigma_grid,
         slong Ns_max, const arb_t H, slong sigma_interp, slong prec)
 {
     fmpz_init(&ctx->T);
@@ -1097,7 +1097,7 @@ slong
 _acb_dirichlet_platt_isolate_local_hardy_z_zeros(
         arf_interval_ptr res, const fmpz_t n, slong len,
         const fmpz_t T, slong A, slong B,
-        const arb_t h, slong J, slong K, slong sigma_grid,
+        const arb_t h, const fmpz_t J, slong K, slong sigma_grid,
         slong Ns_max, const arb_t H, slong sigma_interp, slong prec)
 {
     slong zeros_count;
@@ -1296,7 +1296,7 @@ slong
 _acb_dirichlet_platt_local_hardy_z_zeros(
         arb_ptr res, const fmpz_t n, slong len,
         const fmpz_t T, slong A, slong B,
-        const arb_t h, slong J, slong K, slong sigma_grid,
+        const arb_t h, const fmpz_t J, slong K, slong sigma_grid,
         slong Ns_max, const arb_t H, slong sigma_interp, slong prec)
 {
     slong zeros_count, i;
@@ -1345,9 +1345,9 @@ static platt_ctx_ptr
 _create_heuristic_context(const fmpz_t n, slong prec)
 {
     platt_ctx_ptr p = NULL;
-    slong J, K, A, B, Ns_max, sigma_grid, sigma_interp;
+    slong K, A, B, Ns_max, sigma_grid, sigma_interp;
     slong kbits;
-    fmpz_t T, k;
+    fmpz_t J, T, k;
     arb_t g, h, H, logT;
     double dlogJ, dK, dgrid, dh, dH, dinterp;
     double x, x2, x3, x4;
@@ -1436,7 +1436,7 @@ _create_heuristic_context(const fmpz_t n, slong prec)
 
     arb_set_d(h, dh);
     arb_set_d(H, dH);
-    J = (slong) exp(dlogJ);
+    fmpz_set_si(J, (slong) exp(dlogJ));
     K = (slong) dK;
     sigma_grid = ((slong) (dgrid/2))*2 + 1;
     sigma_interp = ((slong) (dinterp/2))*2 + 1;

--- a/acb_dirichlet/test/t-platt_local_hardy_z_zeros.c
+++ b/acb_dirichlet/test/t-platt_local_hardy_z_zeros.c
@@ -15,9 +15,9 @@ int main()
 {
     /* Check a specific combination of parameter values that is relatively fast
      * to evaluate and that has relatively tight bounds. */
-    slong A, B, J, K, sigma_grid, Ns_max, sigma_interp;
+    slong A, B, K, sigma_grid, Ns_max, sigma_interp;
     arb_t h, H;
-    fmpz_t T, n;
+    fmpz_t J, T, n;
     arb_ptr pa, pb;
     slong count, i;
     slong maxcount = 50;
@@ -28,6 +28,7 @@ int main()
 
     arb_init(h);
     arb_init(H);
+    fmpz_init(J);
     fmpz_init(T);
     fmpz_init(n);
     pa = _arb_vec_init(maxcount);
@@ -41,7 +42,7 @@ int main()
     B = 128;
 
     /* tuning parameters for the evaluation of grid points */
-    J = 1000;
+    fmpz_set_si(J, 1000);
     K = 30;
     sigma_grid = 63;
     arb_set_d(h, 4.5);
@@ -76,6 +77,7 @@ int main()
 
     arb_clear(h);
     arb_clear(H);
+    fmpz_clear(J);
     fmpz_clear(T);
     fmpz_clear(n);
     _arb_vec_clear(pa, maxcount);

--- a/acb_dirichlet/test/t-platt_multieval.c
+++ b/acb_dirichlet/test/t-platt_multieval.c
@@ -74,17 +74,18 @@ int main()
         slong A = 8;
         slong B = 128;
         slong N = A*B;
-        slong J = 1000;
         slong K = 30;
         slong sigma = 63;
         slong prec = 128;
-        fmpz_t T;
+        fmpz_t J, T;
         arb_t h;
         arb_ptr vec;
 
         arb_init(h);
+        fmpz_init(J);
         fmpz_init(T);
 
+        fmpz_set_si(J, 1000);
         fmpz_set_si(T, 10000);
         arb_set_d(h, 4.5);
 
@@ -172,6 +173,7 @@ int main()
             arb_clear(r);
         }
 
+        fmpz_clear(J);
         fmpz_clear(T);
         arb_clear(h);
         _arb_vec_clear(vec, N);
@@ -180,16 +182,15 @@ int main()
     for (iter = 0; iter < 10 * arb_test_multiplier(); iter++)
     {
         slong prec;
-        ulong A, B, N, J, K;
+        ulong A, B, N, K;
         slong sigma, Tbits;
-        fmpz_t T;
+        fmpz_t J, T;
         arb_t h;
         arb_ptr v1, v2;
 
         /* better but slower limits are in parentheses below */
         prec = 2 + n_randint(state, 300);
         sigma = 1 + 2*(1 + n_randint(state, 100)); /* (200) */
-        J = 1 + n_randint(state, 100); /* (10000) */
         K = 1 + n_randint(state, 20); /* (50) */
         A = 1 + n_randint(state, 10);
         B = 1 + n_randint(state, 10); /* (500) */
@@ -199,7 +200,9 @@ int main()
             B *= 2;
         N = A*B;
 
+        fmpz_init(J);
         fmpz_init(T);
+        fmpz_set_si(J, 1 + n_randint(state, 100)); /* (10000) */
         Tbits = 5 + n_randint(state, 15);
         fmpz_set_ui(T, n_randtest_bits(state, Tbits));
 
@@ -217,13 +220,15 @@ int main()
             flint_printf("FAIL: overlap\n\n");
             flint_printf("iter = %wd  prec = %wd\n\n", iter, prec);
             flint_printf("sigma = %wd\n\n", sigma);
-            flint_printf("A = %wu  B = %wu  J = %wu  K = %wu\n\n", A, B, J, K);
+            flint_printf("A = %wu  B = %wu  K = %wu\n\n", A, B, K);
+            flint_printf("J = "); fmpz_print(J); flint_printf("\n\n");
             flint_printf("T = "); fmpz_print(T); flint_printf("\n\n");
             flint_printf("h = "); arb_printn(h, 30, 0); flint_printf("\n\n");
             flint_abort();
         }
 
         arb_clear(h);
+        fmpz_clear(J);
         fmpz_clear(T);
         _arb_vec_clear(v1, N);
         _arb_vec_clear(v2, N);

--- a/acb_dirichlet/test/t-platt_multieval_threaded.c
+++ b/acb_dirichlet/test/t-platt_multieval_threaded.c
@@ -47,17 +47,19 @@ int main()
         slong A = 8;
         slong B = 128;
         slong N = A*B;
-        slong J = 1000;
         slong K = 30;
         slong sigma = 63;
         slong prec = 128;
+        fmpz_t J;
         fmpz_t T;
         arb_t h;
         arb_ptr vec;
 
         arb_init(h);
+        fmpz_init(J);
         fmpz_init(T);
 
+        fmpz_set_si(J, 1000);
         fmpz_set_si(T, 10000);
         arb_set_d(h, 4.5);
 
@@ -88,6 +90,7 @@ int main()
             arb_clear(r);
         }
 
+        fmpz_clear(J);
         fmpz_clear(T);
         arb_clear(h);
         _arb_vec_clear(vec, N);
@@ -96,16 +99,15 @@ int main()
     for (iter = 0; iter < 10 * arb_test_multiplier(); iter++)
     {
         slong prec;
-        ulong A, B, N, J, K;
+        ulong A, B, N, K;
         slong sigma, Tbits;
-        fmpz_t T;
+        fmpz_t J, T;
         arb_t h;
         arb_ptr v1, v2;
 
         /* better but slower limits are in parentheses below */
         prec = 2 + n_randint(state, 300);
         sigma = 1 + 2*(1 + n_randint(state, 100)); /* (200) */
-        J = 1 + n_randint(state, 100); /* (10000) */
         K = 1 + n_randint(state, 20); /* (50) */
         A = 1 + n_randint(state, 10);
         B = 1 + n_randint(state, 10); /* (500) */
@@ -115,7 +117,9 @@ int main()
             B *= 2;
         N = A*B;
 
+        fmpz_init(J);
         fmpz_init(T);
+        fmpz_set_si(J, 1 + n_randint(state, 100)); /* (10000) */
         Tbits = 5 + n_randint(state, 15);
         fmpz_set_ui(T, n_randtest_bits(state, Tbits));
 
@@ -135,13 +139,15 @@ int main()
             flint_printf("FAIL: overlap\n\n");
             flint_printf("iter = %wd  prec = %wd\n\n", iter, prec);
             flint_printf("sigma = %wd\n\n", sigma);
-            flint_printf("A = %wu  B = %wu  J = %wu  K = %wu\n\n", A, B, J, K);
+            flint_printf("A = %wu  B = %wu  K = %wu\n\n", A, B, K);
+            flint_printf("J = "); fmpz_print(J); flint_printf("\n\n");
             flint_printf("T = "); fmpz_print(T); flint_printf("\n\n");
             flint_printf("h = "); arb_printn(h, 30, 0); flint_printf("\n\n");
             flint_abort();
         }
 
         arb_clear(h);
+        fmpz_clear(J);
         fmpz_clear(T);
         _arb_vec_clear(v1, N);
         _arb_vec_clear(v2, N);

--- a/doc/source/acb_dirichlet.rst
+++ b/doc/source/acb_dirichlet.rst
@@ -756,9 +756,9 @@ and formulas described by David J. Platt in [Pla2017]_.
 
 .. function:: void acb_dirichlet_platt_scaled_lambda_vec(arb_ptr res, const fmpz_t T, slong A, slong B, slong prec)
 
-.. function:: void acb_dirichlet_platt_multieval(arb_ptr res, const fmpz_t T, slong A, slong B, const arb_t h, slong J, slong K, slong sigma, slong prec)
+.. function:: void acb_dirichlet_platt_multieval(arb_ptr res, const fmpz_t T, slong A, slong B, const arb_t h, const fmpz_t J, slong K, slong sigma, slong prec)
 
-.. function:: void acb_dirichlet_platt_multieval_threaded(arb_ptr res, const fmpz_t T, slong A, slong B, const arb_t h, slong J, slong K, slong sigma, slong prec)
+.. function:: void acb_dirichlet_platt_multieval_threaded(arb_ptr res, const fmpz_t T, slong A, slong B, const arb_t h, const fmpz_t J, slong K, slong sigma, slong prec)
 
     Compute :func:`acb_dirichlet_platt_scaled_lambda` at `N=AB` points on a
     grid, following the notation of [Pla2017]_. The first point on the grid
@@ -783,7 +783,7 @@ and formulas described by David J. Platt in [Pla2017]_.
     interpolation. *sigma* is an odd positive integer tuning parameter
     `\sigma \in 2\mathbb{Z}_{>0}+1` used in computing error bounds.
 
-.. function:: slong _acb_dirichlet_platt_local_hardy_z_zeros(arb_ptr res, const fmpz_t n, slong len, const fmpz_t T, slong A, slong B, const arb_t h, slong J, slong K, slong sigma_grid, slong Ns_max, const arb_t H, slong sigma_interp, slong prec)
+.. function:: slong _acb_dirichlet_platt_local_hardy_z_zeros(arb_ptr res, const fmpz_t n, slong len, const fmpz_t T, slong A, slong B, const arb_t h, const fmpz_t J, slong K, slong sigma_grid, slong Ns_max, const arb_t H, slong sigma_interp, slong prec)
 .. function:: slong acb_dirichlet_platt_local_hardy_z_zeros(arb_ptr res, const fmpz_t n, slong len, slong prec)
 .. function:: slong acb_dirichlet_platt_hardy_z_zeros(arb_ptr res, const fmpz_t n, slong len, slong prec)
 

--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -463,6 +463,24 @@ squarefree factorization::
     -1.0000
     cpu/wall(s): 0 0.001
 
+zeta_zeros.c
+-------------------------------------------------------------------------------
+
+This program finds the imaginary parts of consecutive nontrivial zeros
+of the Riemann zeta function by calling either
+:func:`acb_dirichlet_hardy_z_zeros` or
+:func:`acb_dirichlet_platt_local_hardy_z_zeros` depending on the height
+of the zeros and the number of zeros requested.
+The program takes the following arguments::
+
+    zeta_zeros [-n n] [-count n] [-prec n] [-threads n] [-platt] [-noplatt] [-v] [-verbose] [-h] [-help]
+
+    > build/examples/zeta_zeros -n 1048449114 -count 2
+    1048449114      [388858886.0022851217767970582 +/- 7.46e-20]
+    1048449115      [388858886.0023936897027167201 +/- 7.59e-20]
+    cpu/wall(s): 0.255 0.255
+    virt/peak/res/peak(MB): 26.77 26.77 7.88 7.88
+
 complex_plot.c
 -------------------------------------------------------------------------------
 

--- a/examples/zeta_zeros.c
+++ b/examples/zeta_zeros.c
@@ -1,0 +1,279 @@
+/* This file is public domain. Author: D.H.J. Polymath. */
+
+#include <string.h>
+#include "acb_dirichlet.h"
+#include "flint/profiler.h"
+
+void print_zeros(arb_srcptr p, const fmpz_t n, slong len, slong digits)
+{
+    slong i;
+    fmpz_t k;
+    fmpz_init_set(k, n);
+    for (i = 0; i < len; i++)
+    {
+        fmpz_print(k);
+        flint_printf("\t");
+        arb_printn(p+i, digits, 0);
+        flint_printf("\n");
+        fmpz_add_ui(k, k, 1);
+    }
+    fmpz_clear(k);
+}
+
+void print_help()
+{
+    flint_printf("zeta_zeros [-n n] [-count n] [-prec n] [-threads n] "
+                 "[-platt] [-noplatt] [-v] [-verbose] [-h] [-help]\n\n");
+    flint_printf("Reports the imaginary parts of consecutive nontrivial zeros "
+                 "of the Riemann zeta function.\n");
+}
+
+void requires_value(int argc, char *argv[], slong i)
+{
+    if (i == argc-1)
+    {
+        flint_printf("the argument %s requires a value\n", argv[i]);
+        flint_abort();
+    }
+}
+
+void invalid_value(char *argv[], slong i)
+{
+    flint_printf("invalid value for the argument %s: %s\n", argv[i], argv[i+1]);
+    flint_abort();
+}
+
+int main(int argc, char *argv[])
+{
+    const slong max_buffersize = 30000;
+    int verbose = 0;
+    int platt = 0;
+    int noplatt = 0;
+    slong i, buffersize, prec;
+    fmpz_t requested, count, nstart, n;
+    arb_ptr p;
+
+    for (i = 1; i < argc; i++)
+    {
+        if (!strcmp(argv[i], "-h") || !strcmp(argv[i], "-help"))
+        {
+            print_help();
+            return 0;
+        }
+    }
+
+    fmpz_init(requested);
+    fmpz_init(count);
+    fmpz_init(nstart);
+    fmpz_init(n);
+
+    fmpz_one(nstart);
+    fmpz_set_si(requested, -1);
+    buffersize = max_buffersize;
+    prec = -1;
+
+    for (i = 1; i < argc; i++)
+    {
+        if (!strcmp(argv[i], "-noplatt"))
+        {
+            noplatt = 1;
+        }
+        else if (!strcmp(argv[i], "-platt"))
+        {
+            platt = 1;
+        }
+        else if (!strcmp(argv[i], "-v") || !strcmp(argv[i], "-verbose"))
+        {
+            verbose = 1;
+        }
+        else if (!strcmp(argv[i], "-threads"))
+        {
+            slong threads;
+            requires_value(argc, argv, i);
+            threads = atol(argv[i+1]);
+            if (threads < 1)
+            {
+                invalid_value(argv, i);
+            }
+            flint_set_num_threads(threads);
+        }
+        else if (!strcmp(argv[i], "-n"))
+        {
+            requires_value(argc, argv, i);
+            if (fmpz_set_str(nstart, argv[i+1], 10) || fmpz_sgn(nstart) < 1)
+            {
+                invalid_value(argv, i);
+            }
+        }
+        else if (!strcmp(argv[i], "-count"))
+        {
+            requires_value(argc, argv, i);
+            if (fmpz_set_str(requested, argv[i+1], 10) ||
+                fmpz_sgn(requested) < 1)
+            {
+                invalid_value(argv, i);
+            }
+            if (fmpz_cmp_si(requested, buffersize) < 0)
+            {
+                buffersize = fmpz_get_si(requested);
+            }
+        }
+        else if (!strcmp(argv[i], "-prec"))
+        {
+            requires_value(argc, argv, i);
+            prec = atol(argv[i+1]);
+            if (prec < 2)
+            {
+                invalid_value(argv, i);
+            }
+        }
+    }
+
+    if (platt && noplatt)
+    {
+        flint_printf("conflicting arguments platt and noplatt\n");
+        flint_abort();
+    }
+
+    if (platt && fmpz_cmp_si(nstart, 10000) < 0)
+    {
+        flint_printf("this implementation of the platt algorithm "
+                     "is not valid below the 10000th zero\n");
+        flint_abort();
+    }
+
+    /* Above n~1e15 the large height method is better.
+     * Above n~1e11 the large height method is better for more than 100 zeros.
+     * Don't worry about crossing the threshold, just use the method
+     * that is better at the beginning of the run.
+     */
+    if (!noplatt && !platt)
+    {
+        fmpz_t threshold;
+        fmpz_init(threshold);
+        fmpz_set_si(threshold, 10);
+        fmpz_pow_ui(threshold, threshold, 15);
+        if (fmpz_sgn(requested) < 0 || fmpz_cmp_si(requested, 100) > 0)
+        {
+            fmpz_set_si(threshold, 10);
+            fmpz_pow_ui(threshold, threshold, 11);
+        }
+        if (fmpz_cmp(nstart, threshold) < 0)
+        {
+            noplatt = 1;
+        }
+        else
+        {
+            platt = 1;
+        }
+        fmpz_clear(threshold);
+    }
+
+    if (prec == -1)
+    {
+        prec = 64 + fmpz_clog_ui(nstart, 2);
+        if (platt) prec *= 2;
+    }
+
+    if (verbose)
+    {
+        flint_printf("n: "); fmpz_print(nstart); flint_printf("\n");
+        flint_printf("count: "); fmpz_print(requested); flint_printf("\n");
+        flint_printf("threads: %wd\n", flint_get_num_threads());
+        flint_printf("prec: %wd\n", prec);
+        if (platt)
+        {
+            flint_printf("method: platt (good for large heights, "
+                         "many consecutive zeros, and lower precision; "
+                         "interprets prec as a working precision)\n");
+        }
+        else
+        {
+            flint_printf("method: noplatt (good for small heights, "
+                         "few consecutive zeros, and greater precision; "
+                         "interprets prec as a goal precision)\n");
+        }
+    }
+
+    p = _arb_vec_init(buffersize);
+    fmpz_set(n, nstart);
+    fmpz_zero(count);
+
+    TIMEIT_ONCE_START
+
+    /* This is the low height method. */
+    if (noplatt)
+    {
+        fmpz_t iter;
+        fmpz_init(iter);
+        while (fmpz_sgn(requested) < 0 || fmpz_cmp(count, requested) < 0)
+        {
+            slong num = buffersize;
+            if (fmpz_sgn(requested) >= 0)
+            {
+                fmpz_t remaining;
+                fmpz_init(remaining);
+                fmpz_sub(remaining, requested, count);
+                if (fmpz_cmp_si(remaining, num) < 0)
+                {
+                    num = fmpz_get_si(remaining);
+                }
+                fmpz_clear(remaining);
+            }
+            if (fmpz_cmp_si(iter, 30) < 0)
+            {
+                num = FLINT_MIN(1 << fmpz_get_si(iter), num);
+            }
+            acb_dirichlet_hardy_z_zeros(p, n, num, prec);
+            print_zeros(p, n, num, prec*0.3 + 2);
+            fmpz_add_si(n, n, num);
+            fmpz_add_si(count, count, num);
+            fmpz_add_si(iter, iter, 1);
+        }
+        fmpz_clear(iter);
+    }
+
+    /* This is the large height method. */
+    if (platt)
+    {
+        while (fmpz_sgn(requested) < 0 || fmpz_cmp(count, requested) < 0)
+        {
+            slong found;
+            slong num = buffersize;
+            if (fmpz_sgn(requested) >= 0)
+            {
+                fmpz_t remaining;
+                fmpz_init(remaining);
+                fmpz_sub(remaining, requested, count);
+                if (fmpz_cmp_si(remaining, num) < 0)
+                {
+                    num = fmpz_get_si(remaining);
+                }
+                fmpz_clear(remaining);
+            }
+            found = acb_dirichlet_platt_local_hardy_z_zeros(p, n, num, prec);
+            if (!found)
+            {
+                flint_printf("Failed to find some zeros.\n");
+                flint_printf("Maybe prec is not high enough or something "
+                             "is wrong with the internal tuning parameters.");
+                flint_abort();
+            }
+            print_zeros(p, n, found, prec*0.3 + 2);
+            fmpz_add_si(n, n, found);
+            fmpz_add_si(count, count, found);
+        }
+    }
+
+    TIMEIT_ONCE_STOP
+    SHOW_MEMORY_USAGE
+
+    _arb_vec_clear(p, buffersize);
+    fmpz_clear(nstart);
+    fmpz_clear(n);
+    fmpz_clear(requested);
+    fmpz_clear(count);
+
+    flint_cleanup();
+    return 0;
+}


### PR DESCRIPTION
closes https://github.com/fredrik-johansson/arb/issues/349

I think the old code would overflow at large heights if slong is 32 bits.