### PR TITLE
improve bessel k expansion transition

### DIFF
--- a/acb_hypgeom/bessel_k.c
+++ b/acb_hypgeom/bessel_k.c
@@ -205,37 +205,52 @@ acb_hypgeom_bessel_k_0f1(acb_t res, const acb_t nu, const acb_t z, int scaled, s
     }
 }
 
+static int
+_use_bessel_k_0f1(const acb_t nu, const acb_t z, slong prec)
+{
+    slong result = 0;
+    mag_t zmag;
+    mag_init(zmag);
+    acb_get_mag(zmag, z);
+    if (mag_cmp_2exp_si(zmag, 4) < 0)
+    {
+        result = 1;
+    }
+    else if (mag_cmp_2exp_si(zmag, 64) >= 0)
+    {
+        result = 0;
+    }
+    else
+    {
+        if (acb_is_real(nu) && arb_is_positive(acb_realref(nu)) &&
+            acb_is_real(z) && arb_is_positive(acb_realref(z)))
+        {
+            result = mag_get_d(zmag) < 0.172 * prec - 1;
+        }
+        else
+        {
+            result = 2 * mag_get_d(zmag) < prec;
+        }
+    }
+    mag_clear(zmag);
+    return result;
+}
+
 void
 acb_hypgeom_bessel_k(acb_t res, const acb_t nu, const acb_t z, slong prec)
 {
-    mag_t zmag;
-
-    mag_init(zmag);
-    acb_get_mag(zmag, z);
-
-    if (mag_cmp_2exp_si(zmag, 4) < 0 ||
-        (mag_cmp_2exp_si(zmag, 64) < 0 && mag_get_d(zmag) < 0.172 * prec - 1))
+    if (_use_bessel_k_0f1(nu, z, prec))
         acb_hypgeom_bessel_k_0f1(res, nu, z, 0, prec);
     else
         acb_hypgeom_bessel_k_asymp(res, nu, z, 0, prec);
-
-    mag_clear(zmag);
 }
 
 void
 acb_hypgeom_bessel_k_scaled(acb_t res, const acb_t nu, const acb_t z, slong prec)
 {
-    mag_t zmag;
-
-    mag_init(zmag);
-    acb_get_mag(zmag, z);
-
-    if (mag_cmp_2exp_si(zmag, 4) < 0 ||
-        (mag_cmp_2exp_si(zmag, 64) < 0 && mag_get_d(zmag) < 0.172 * prec - 1))
+    if (_use_bessel_k_0f1(nu, z, prec))
         acb_hypgeom_bessel_k_0f1(res, nu, z, 1, prec);
     else
         acb_hypgeom_bessel_k_asymp(res, nu, z, 1, prec);
-
-    mag_clear(zmag);
 }
 

--- a/acb_hypgeom/bessel_k.c
+++ b/acb_hypgeom/bessel_k.c
@@ -214,7 +214,7 @@ acb_hypgeom_bessel_k(acb_t res, const acb_t nu, const acb_t z, slong prec)
     acb_get_mag(zmag, z);
 
     if (mag_cmp_2exp_si(zmag, 4) < 0 ||
-        (mag_cmp_2exp_si(zmag, 64) < 0 && 2 * mag_get_d(zmag) < prec))
+        (mag_cmp_2exp_si(zmag, 64) < 0 && mag_get_d(zmag) < 0.172 * prec - 1))
         acb_hypgeom_bessel_k_0f1(res, nu, z, 0, prec);
     else
         acb_hypgeom_bessel_k_asymp(res, nu, z, 0, prec);
@@ -231,7 +231,7 @@ acb_hypgeom_bessel_k_scaled(acb_t res, const acb_t nu, const acb_t z, slong prec
     acb_get_mag(zmag, z);
 
     if (mag_cmp_2exp_si(zmag, 4) < 0 ||
-        (mag_cmp_2exp_si(zmag, 64) < 0 && 2 * mag_get_d(zmag) < prec))
+        (mag_cmp_2exp_si(zmag, 64) < 0 && mag_get_d(zmag) < 0.172 * prec - 1))
         acb_hypgeom_bessel_k_0f1(res, nu, z, 1, prec);
     else
         acb_hypgeom_bessel_k_asymp(res, nu, z, 1, prec);

--- a/acb_hypgeom/test/t-bessel_k.c
+++ b/acb_hypgeom/test/t-bessel_k.c
@@ -11,6 +11,51 @@
 
 #include "acb_hypgeom.h"
 
+static void
+gh_issue_360_regression_test()
+{
+    slong prec, bits;
+    acb_t nu, z, w;
+
+    acb_init(nu);
+    acb_init(z);
+    acb_init(w);
+
+    prec = 128;
+    acb_set_d(nu, 2.0);
+    acb_set_d(z, 58.0);
+
+    /* unscaled */
+    acb_hypgeom_bessel_k(w, nu, z, prec);
+    bits = arb_rel_accuracy_bits(acb_realref(w));
+    if (bits < 100)
+    {
+        flint_printf("FAIL: gh issue 360 regression (unscaled)\n\n");
+        flint_printf("nu = "); acb_printd(nu, 30); flint_printf("\n\n");
+        flint_printf("z = ");  acb_printd(z, 30); flint_printf("\n\n");
+        flint_printf("w = "); acb_printd(w, 30); flint_printf("\n\n");
+        flint_printf("bits: %wd\n\n", bits);
+        flint_abort();
+    }
+
+    /* scaled */
+    acb_hypgeom_bessel_k_scaled(w, nu, z, prec);
+    bits = arb_rel_accuracy_bits(acb_realref(w));
+    if (bits < 100)
+    {
+        flint_printf("FAIL: gh issue 360 regression (scaled)\n\n");
+        flint_printf("nu = "); acb_printd(nu, 30); flint_printf("\n\n");
+        flint_printf("z = ");  acb_printd(z, 30); flint_printf("\n\n");
+        flint_printf("w = "); acb_printd(w, 30); flint_printf("\n\n");
+        flint_printf("bits: %wd\n\n", bits);
+        flint_abort();
+    }
+
+    acb_clear(nu);
+    acb_clear(z);
+    acb_clear(w);
+}
+
 int main()
 {
     slong iter;
@@ -161,6 +206,8 @@ int main()
         acb_clear(t);
         acb_clear(u);
     }
+
+    gh_issue_360_regression_test();
 
     flint_randclear(state);
     flint_cleanup();


### PR DESCRIPTION
See https://github.com/fredrik-johansson/arb/issues/360.

For positive real nu and z, the cutoff criterion appears to be affine and not depend on nu. I didn't check other values of nu or z.

Evaluating `besselk(2.0, 57.9668555791947111700112064539202300037282162)` for various precisions:

Before:
```
100 [1.136872868128306888443825590e-26 +/- 2.95e-54]
110 [1.136872868128306888443825589950e-26 +/- 4.01e-57]
120 [+/- 1.19e-9]
130 [+/- 1.17e-12]
140 [+/- 1.18e-15]
150 [+/- 1.15e-18]
160 [+/- 1.14e-21]
170 [+/- 1.13e-24]
180 [1e-26 +/- 2.46e-27]
190 [1.137e-26 +/- 2.36e-30]
200 [1.136873e-26 +/- 2.39e-33]
210 [1.136872868e-26 +/- 2.35e-36]
220 [1.136872868128e-26 +/- 4.11e-39]
230 [1.136872868128307e-26 +/- 2.14e-42]
240 [1.136872868128306888e-26 +/- 5.46e-45]
250 [1.136872868128306888444e-26 +/- 2.75e-48]
```

After:
```
100 [1.136872868128306888443825590e-26 +/- 2.95e-54]
110 [1.136872868128306888443825589950e-26 +/- 4.01e-57]
120 [1.136872868128306888443825589950094e-26 +/- 6.98e-60]
130 [1.1368728681283068884438255899500943247e-26 +/- 6.98e-64]
140 [1.136872868128306888443825589950094324651e-26 +/- 1.13e-66]
150 [1.1368728681283068884438255899500943246509356e-26 +/- 6.42e-70]
160 [1.136872868128306888443825589950094324650935557e-26 +/- 5.01e-72]
170 [1.136872868128306888443825589950094324650935557413e-26 +/- 3.10e-75]
180 [1.13687286812830688844382558995009432465093555741322e-26 +/- 5.56e-77]
190 [1.13687286812830688844382558995009432465093555741322e-26 +/- 5.48e-77]
200 [1.13687286812830688844382558995009432465093555741322e-26 +/- 5.48e-77]
210 [1.13687286812830688844382558995009432465093555741322e-26 +/- 5.48e-77]
220 [1.13687286812830688844382558995009432465093555741322e-26 +/- 5.48e-77]
230 [1.13687286812830688844382558995009432465093555741322e-26 +/- 5.48e-77]
240 [1.13687286812830688844382558995009432465093555741322e-26 +/- 5.48e-77]
250 [1.13687286812830688844382558995009432465093555741322e-26 +/- 5.48e-77]
```