### PR TITLE
Fixed bug for aliased mat_mul of window matrices

### DIFF
--- a/acb_mat.h
+++ b/acb_mat.h
@@ -66,6 +66,16 @@ acb_mat_swap(acb_mat_t mat1, acb_mat_t mat2)
     *mat2 = t;
 }
 
+ACB_MAT_INLINE void
+acb_mat_swap_entrywise(acb_mat_t mat1, acb_mat_t mat2)
+{
+    slong i, j;
+
+    for (i = 0; i < acb_mat_nrows(mat1); i++)
+        for (j = 0; j < acb_mat_ncols(mat1); j++)
+            acb_swap(acb_mat_entry(mat2, i, j), acb_mat_entry(mat1, i, j));
+}
+
 /* Window matrices */
 
 void acb_mat_window_init(acb_mat_t window, const acb_mat_t mat, slong r1, slong c1, slong r2, slong c2);

--- a/acb_mat/approx_mul.c
+++ b/acb_mat/approx_mul.c
@@ -38,7 +38,7 @@ acb_mat_approx_mul_classical(acb_mat_t C, const acb_mat_t A, const acb_mat_t B, 
         acb_mat_t T;
         acb_mat_init(T, ar, bc);
         acb_mat_approx_mul_classical(T, A, B, prec);
-        acb_mat_swap(T, C);
+        acb_mat_swap_entrywise(T, C);
         acb_mat_clear(T);
         return;
     }

--- a/acb_mat/mul_classical.c
+++ b/acb_mat/mul_classical.c
@@ -45,7 +45,7 @@ acb_mat_mul_classical(acb_mat_t C, const acb_mat_t A, const acb_mat_t B, slong p
         acb_mat_t T;
         acb_mat_init(T, ar, bc);
         acb_mat_mul_classical(T, A, B, prec);
-        acb_mat_swap(T, C);
+        acb_mat_swap_entrywise(T, C);
         acb_mat_clear(T);
         return;
     }

--- a/acb_mat/mul_threaded.c
+++ b/acb_mat/mul_threaded.c
@@ -87,7 +87,7 @@ acb_mat_mul_threaded(acb_mat_t C, const acb_mat_t A, const acb_mat_t B, slong pr
         acb_mat_t T;
         acb_mat_init(T, ar, bc);
         acb_mat_mul_threaded(T, A, B, prec);
-        acb_mat_swap(T, C);
+        acb_mat_swap_entrywise(T, C);
         acb_mat_clear(T);
         return;
     }

--- a/arb_mat.h
+++ b/arb_mat.h
@@ -64,6 +64,16 @@ arb_mat_swap(arb_mat_t mat1, arb_mat_t mat2)
     *mat2 = t;
 }
 
+ARB_MAT_INLINE void
+arb_mat_swap_entrywise(arb_mat_t mat1, arb_mat_t mat2)
+{
+    slong i, j;
+
+    for (i = 0; i < arb_mat_nrows(mat1); i++)
+        for (j = 0; j < arb_mat_ncols(mat1); j++)
+            arb_swap(arb_mat_entry(mat2, i, j), arb_mat_entry(mat1, i, j));
+}
+
 /* Window matrices */
 
 void arb_mat_window_init(arb_mat_t window, const arb_mat_t mat, slong r1, slong c1, slong r2, slong c2);

--- a/arb_mat/approx_mul.c
+++ b/arb_mat/approx_mul.c
@@ -31,7 +31,7 @@ arb_mat_approx_mul_classical(arb_mat_t C, const arb_mat_t A, const arb_mat_t B, 
         arb_mat_t T;
         arb_mat_init(T, ar, bc);
         arb_mat_approx_mul_classical(T, A, B, prec);
-        arb_mat_swap(T, C);
+        arb_mat_swap_entrywise(T, C);
         arb_mat_clear(T);
         return;
     }

--- a/arb_mat/mul_block.c
+++ b/arb_mat/mul_block.c
@@ -238,7 +238,7 @@ arb_mat_mul_block(arb_mat_t C, const arb_mat_t A, const arb_mat_t B, slong prec)
         arb_mat_t T;
         arb_mat_init(T, M, P);
         arb_mat_mul_block(T, A, B, prec);
-        arb_mat_swap(T, C);
+        arb_mat_swap_entrywise(T, C);
         arb_mat_clear(T);
         return;
     }

--- a/arb_mat/mul_classical.c
+++ b/arb_mat/mul_classical.c
@@ -45,7 +45,7 @@ arb_mat_mul_classical(arb_mat_t C, const arb_mat_t A, const arb_mat_t B, slong p
         arb_mat_t T;
         arb_mat_init(T, ar, bc);
         arb_mat_mul_classical(T, A, B, prec);
-        arb_mat_swap(T, C);
+        arb_mat_swap_entrywise(T, C);
         arb_mat_clear(T);
         return;
     }

--- a/arb_mat/mul_threaded.c
+++ b/arb_mat/mul_threaded.c
@@ -87,7 +87,7 @@ arb_mat_mul_threaded(arb_mat_t C, const arb_mat_t A, const arb_mat_t B, slong pr
         arb_mat_t T;
         arb_mat_init(T, ar, bc);
         arb_mat_mul_threaded(T, A, B, prec);
-        arb_mat_swap(T, C);
+        arb_mat_swap_entrywise(T, C);
         arb_mat_clear(T);
         return;
     }


### PR DESCRIPTION
I noticed that most `mat_mul`-functions (with `mat_mul_entrywise` being an exception) do not work properly for aliased window-matrices. The reason for this is that `mat_swap` destroys the entanglement of the window matrices with their parent matrix.
This can be seen with the following code-snippet:
```
void arb_mat_mul_aliased_window_test(){
    arb_mat_t A, B, A_window;
    arb_mat_init(A, 2, 2);
    arb_mat_init(B, 2, 2);
    arb_mat_window_init(A_window, A, 0, 0, 2, 2);
    arb_mat_one(A);
    arb_mat_ones(B);

    printf("Before multiplication: \n");
    printf("A: \n");
    arb_mat_printd(A, 10);
    printf("A_window: \n");
    arb_mat_printd(A_window, 10);
    arb_mat_mul_classical(A_window, B, A_window, 53);
    printf("After multiplication: \n");
    printf("A: \n");
    arb_mat_printd(A, 10);
    printf("A_window: \n");
    arb_mat_printd(A_window, 10);

    arb_mat_window_clear(A_window);
    arb_mat_clear(A);
    arb_mat_clear(B);
}
```
Which produces:
```
Before multiplication:
A:
[1 +/- 0, 0 +/- 0]
[0 +/- 0, 1 +/- 0]
A_window:
[1 +/- 0, 0 +/- 0]
[0 +/- 0, 1 +/- 0]
After multiplication:
A:
[1 +/- 0, 0 +/- 0]
[0 +/- 0, 1 +/- 0]
A_window:
[1 +/- 0, 1 +/- 0]
[1 +/- 0, 1 +/- 0]
```
As you can see, `A` no longer holds the correct result.

My fix performs the pointer-swaps entrywise which makes sure that the corresponding parent object gets updated accordingly. We now have to do O(N^2) pointer-swaps instead of O(1) but the performance impact should be negligible.