### PR TITLE
Minor documentation changes

### DIFF
--- a/doc/source/acb.rst
+++ b/doc/source/acb.rst
@@ -653,11 +653,11 @@ Exponentials and logarithms
 
 .. function:: void acb_exp_invexp(acb_t s, acb_t t, const acb_t z, slong prec)
 
-    Sets `v = \exp(z)` and `w = \exp(-z)`.
+    Sets `s = \exp(z)` and `t = \exp(-z)`.
 
 .. function:: void acb_expm1(acb_t res, const acb_t z, slong prec)
 
-    Computes `\exp(z)-1`, using an accurate method when `z \approx 0`.
+    Sets *res* to `\exp(z)-1`, using an accurate method when `z \approx 0`.
 
 .. function:: void acb_log(acb_t y, const acb_t z, slong prec)
 

--- a/doc/source/acb.rst
+++ b/doc/source/acb.rst
@@ -666,7 +666,7 @@ Exponentials and logarithms
 
 .. function:: void acb_expm1(acb_t res, const acb_t z, slong prec)
 
-    Sets *res* to `\exp(z)-1`, using an accurate method when `z \approx 0`.
+    Sets *res* to `\exp(z)-1`, using a more accurate method when `z \approx 0`.
 
 .. function:: void acb_log(acb_t y, const acb_t z, slong prec)
 

--- a/doc/source/arb.rst
+++ b/doc/source/arb.rst
@@ -1065,7 +1065,7 @@ Exponentials and logarithms
 
 .. function:: void arb_expm1(arb_t z, const arb_t x, slong prec)
 
-    Sets `z = \exp(x)-1`, using an accurate method when `x \approx 0`.
+    Sets `z = \exp(x)-1`, using a more accurate method when `x \approx 0`.
 
 .. function:: void arb_exp_invexp(arb_t z, arb_t w, const arb_t x, slong prec)
 

--- a/doc/source/arb.rst
+++ b/doc/source/arb.rst
@@ -1055,7 +1055,7 @@ Exponentials and logarithms
 
 .. function:: void arb_expm1(arb_t z, const arb_t x, slong prec)
 
-    Sets `z = \exp(x)-1`, computed accurately when `x \approx 0`.
+    Sets `z = \exp(x)-1`, using an accurate method when `x \approx 0`.
 
 .. function:: void arb_exp_invexp(arb_t z, arb_t w, const arb_t x, slong prec)
 


### PR DESCRIPTION
I assume that `arb_expm1` does not compute incorrectly for larger `x`, and I therefore copied the documentation from `acb_expm1`.

I also took the liberty of changing some symbols that I suspect where copy-pasta from somewhere.