### PR TITLE
Implement Graeffe Transform for arb_poly and acb_poly

### DIFF
--- a/acb_poly.h
+++ b/acb_poly.h
@@ -193,6 +193,10 @@ void _acb_poly_binomial_transform(acb_ptr b, acb_srcptr a, slong alen, slong len
 
 void acb_poly_binomial_transform(acb_poly_t b, const acb_poly_t a, slong len, slong prec);
 
+void _acb_poly_graeffe_transform(acb_ptr b, acb_srcptr a, slong len, slong prec);
+
+void acb_poly_graeffe_transform(acb_poly_t b, const acb_poly_t a, slong prec);
+
 
 
 void acb_poly_set(acb_poly_t dest, const acb_poly_t src);

--- a/acb_poly/graeffe_transform.c
+++ b/acb_poly/graeffe_transform.c
@@ -1,0 +1,52 @@
+/*
+    Copyright (C) 2012 Fredrik Johansson
+
+    This file is part of Arb.
+
+    Arb is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "acb_poly.h"
+
+void
+_acb_poly_graeffe_transform(acb_ptr b, acb_srcptr a, slong len, slong prec)
+{
+    if (len == 0)
+        return;
+
+    slong q, i;
+
+    q = (len-1)/2+1;
+    acb_ptr pe = _acb_vec_init(q);
+    acb_ptr po = _acb_vec_init(len);
+
+    for (i = len-1; i >= 0; i--)
+    {
+        if (i % 2 == 0)
+            acb_set(pe+i/2, a+i);
+        else
+            acb_set(po+i/2, a+i);
+    }
+
+    _acb_poly_mul(b, po, q, po, q, prec);
+    _acb_poly_shift_left(b, b, len-1, 1);
+    _acb_poly_mul(po, pe, q, pe, q, prec);
+    _acb_vec_sub(b, po, b, len, prec);
+
+    _acb_vec_clear(pe, q);
+    _acb_vec_clear(po, len);
+
+    if (len % 2 == 0)
+	    _acb_vec_neg(b, b, len);
+}
+
+void
+acb_poly_graeffe_transform(acb_poly_t b, const acb_poly_t a, slong prec)
+{
+    acb_poly_fit_length(b, a->length);
+    _acb_poly_graeffe_transform(b->coeffs, a->coeffs, a->length, prec);
+    _acb_poly_set_length(b, a->length);
+}

--- a/acb_poly/graeffe_transform.c
+++ b/acb_poly/graeffe_transform.c
@@ -19,20 +19,20 @@ _acb_poly_graeffe_transform(acb_ptr b, acb_srcptr a, slong len, slong prec)
 
     slong q, i;
 
-    q = (len-1)/2+1;
+    q = (len - 1) / 2 + 1;
     acb_ptr pe = _acb_vec_init(q);
     acb_ptr po = _acb_vec_init(len);
 
-    for (i = len-1; i >= 0; i--)
+    for (i = len - 1; i >= 0; i--)
     {
         if (i % 2 == 0)
-            acb_set(pe+i/2, a+i);
+            acb_set(pe + i / 2, a + i);
         else
-            acb_set(po+i/2, a+i);
+            acb_set(po + i / 2, a + i);
     }
 
     _acb_poly_mul(b, po, q, po, q, prec);
-    _acb_poly_shift_left(b, b, len-1, 1);
+    _acb_poly_shift_left(b, b, len - 1, 1);
     _acb_poly_mul(po, pe, q, pe, q, prec);
     _acb_vec_sub(b, po, b, len, prec);
 

--- a/acb_poly/graeffe_transform.c
+++ b/acb_poly/graeffe_transform.c
@@ -14,8 +14,7 @@
 void
 _acb_poly_graeffe_transform(acb_ptr b, acb_srcptr a, slong len, slong prec)
 {
-    slong lo, le, ls;
-    slong i;
+    slong lo, le, ls, deg, i;
     acb_ptr pe, po;
 
     if (len <= 1)
@@ -24,13 +23,14 @@ _acb_poly_graeffe_transform(acb_ptr b, acb_srcptr a, slong len, slong prec)
         return;
     }
 
+    deg = len - 1;
     lo = len / 2;
     ls = 2 * lo - 1;
-    le = (len - 1) / 2 + 1;
+    le = deg / 2 + 1;
     po = _acb_vec_init(lo);
     pe = _acb_vec_init(FLINT_MAX(le, ls));
 
-    for (i = len - 1; i >= 0; i--)
+    for (i = deg; i >= 0; i--)
     {
         if (i % 2 == 0)
             acb_set(pe + i / 2, a + i);
@@ -44,8 +44,8 @@ _acb_poly_graeffe_transform(acb_ptr b, acb_srcptr a, slong len, slong prec)
 
     if (len % 2 == 0)
     {
-        _acb_vec_neg(b, b, len - 1);
-        acb_set(b + (len - 1), pe + (len - 2));
+        _acb_vec_neg(b, b, deg);
+        acb_set(b + deg, pe + (deg - 1));
     }
 
     _acb_vec_clear(pe, FLINT_MAX(le, ls));

--- a/acb_poly/graeffe_transform.c
+++ b/acb_poly/graeffe_transform.c
@@ -14,14 +14,21 @@
 void
 _acb_poly_graeffe_transform(acb_ptr b, acb_srcptr a, slong len, slong prec)
 {
-    if (len == 0)
+    slong lo, le, ls;
+    slong i;
+    acb_ptr pe, po;
+
+    if (len <= 1)
+    {
+        _acb_vec_set(b, a, len);
         return;
+    }
 
-    slong q, i;
-
-    q = (len - 1) / 2 + 1;
-    acb_ptr pe = _acb_vec_init(q);
-    acb_ptr po = _acb_vec_init(len);
+    lo = len / 2;
+    ls = 2 * lo - 1;
+    le = (len - 1) / 2 + 1;
+    po = _acb_vec_init(lo);
+    pe = _acb_vec_init(FLINT_MAX(le, ls));
 
     for (i = len - 1; i >= 0; i--)
     {
@@ -31,16 +38,18 @@ _acb_poly_graeffe_transform(acb_ptr b, acb_srcptr a, slong len, slong prec)
             acb_set(po + i / 2, a + i);
     }
 
-    _acb_poly_mul(b, po, q, po, q, prec);
-    _acb_poly_shift_left(b, b, len - 1, 1);
-    _acb_poly_mul(po, pe, q, pe, q, prec);
-    _acb_vec_sub(b, po, b, len, prec);
-
-    _acb_vec_clear(pe, q);
-    _acb_vec_clear(po, len);
+    _acb_poly_mul(b, pe, le, pe, le, prec);
+    _acb_poly_mul(pe, po, lo, po, lo, prec);
+    _acb_poly_sub(b + 1, b + 1, ls, pe, ls, prec);
 
     if (len % 2 == 0)
-	    _acb_vec_neg(b, b, len);
+    {
+        _acb_vec_neg(b, b, len - 1);
+        acb_set(b + (len - 1), pe + (len - 2));
+    }
+
+    _acb_vec_clear(pe, FLINT_MAX(le, ls));
+    _acb_vec_clear(po, lo);
 }
 
 void

--- a/acb_poly/graeffe_transform.c
+++ b/acb_poly/graeffe_transform.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2012 Fredrik Johansson
+    Copyright (C) 2021 Matthias Gessinger
 
     This file is part of Arb.
 

--- a/acb_poly/test/t-graeffe_transform.c
+++ b/acb_poly/test/t-graeffe_transform.c
@@ -15,13 +15,13 @@ int main()
 {
     slong iter;
     flint_rand_t state;
+    acb_poly_t a, b, c;
 
     flint_printf("graeffe_transform....");
     fflush(stdout);
 
     flint_randinit(state);
 
-    acb_poly_t a, b, c;
     acb_poly_init(a);
     acb_poly_init(b);
     acb_poly_init(c);
@@ -31,6 +31,7 @@ int main()
     for (iter = 0; iter < 200 * arb_test_multiplier(); iter++)
     {
         slong n, prec, i;
+
         n = n_randint(state, 20);
         prec = 2 + n_randint(state, 256);
 
@@ -47,7 +48,7 @@ int main()
         acb_poly_graeffe_transform(b, a, prec);
         if (!acb_poly_overlaps(b, c))
         {
-            flint_printf("FAIL (containment)\n\n");
+            flint_printf("FAIL (overlap)\n\n");
             flint_printf("n = %wd, prec = %wd\n\n", n, prec);
 
             flint_printf("a: "); acb_poly_printd(a, 15); flint_printf("\n\n");

--- a/acb_poly/test/t-graeffe_transform.c
+++ b/acb_poly/test/t-graeffe_transform.c
@@ -28,21 +28,20 @@ int main()
 
     acb_ptr roots;
 
-    for (iter = 0; iter < 500 * arb_test_multiplier(); iter++)
+    for (iter = 0; iter < 200 * arb_test_multiplier(); iter++)
     {
         slong n, prec, i;
-        n = n_randint(state, 200);
-        prec = 2 + n_randint(state, 200);
+        n = n_randint(state, 20);
+        prec = 2 + n_randint(state, 256);
 
         roots = _acb_vec_init(n);
-        for (i = 0; i < n; i++)
-                acb_randtest(roots+i, state, prec, n_randint(state, 10));
 
+        for (i = 0; i < n; i++)
+                acb_randtest(roots + i, state, prec, n_randint(state, 16));
         acb_poly_product_roots(a, roots, n, prec);
 
         for (i = 0; i < n; i++)
-                acb_sqr(roots+i, roots+i, prec);
-
+                acb_sqr(roots + i, roots + i, prec);
         acb_poly_product_roots(c, roots, n, prec);
 
         acb_poly_graeffe_transform(b, a, prec);

--- a/acb_poly/test/t-graeffe_transform.c
+++ b/acb_poly/test/t-graeffe_transform.c
@@ -1,0 +1,86 @@
+/*
+    Copyright (C) 2013 Fredrik Johansson
+
+    This file is part of Arb.
+
+    Arb is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "acb_poly.h"
+
+int main()
+{
+    slong iter;
+    flint_rand_t state;
+
+    flint_printf("graeffe_transform....");
+    fflush(stdout);
+
+    flint_randinit(state);
+
+    acb_poly_t a, b, c;
+    acb_poly_init(a);
+    acb_poly_init(b);
+    acb_poly_init(c);
+
+    acb_ptr roots;
+
+    for (iter = 0; iter < 500 * arb_test_multiplier(); iter++)
+    {
+        slong n, prec, i;
+        n = n_randint(state, 200);
+        prec = 2 + n_randint(state, 200);
+
+        roots = _acb_vec_init(n);
+        for (i = 0; i < n; i++)
+                acb_randtest(roots+i, state, prec, n_randint(state, 10));
+
+        acb_poly_product_roots(a, roots, n, prec);
+
+        for (i = 0; i < n; i++)
+                acb_sqr(roots+i, roots+i, prec);
+
+        acb_poly_product_roots(c, roots, n, prec);
+
+        acb_poly_graeffe_transform(b, a, prec);
+        if (!acb_poly_overlaps(b, c))
+        {
+            flint_printf("FAIL (containment)\n\n");
+            flint_printf("n = %wd, prec = %wd\n\n", n, prec);
+
+            flint_printf("a: "); acb_poly_printd(a, 15); flint_printf("\n\n");
+            flint_printf("b: "); acb_poly_printd(b, 15); flint_printf("\n\n");
+            flint_printf("c: "); acb_poly_printd(c, 15); flint_printf("\n\n");
+
+            flint_abort();
+        }
+
+        acb_poly_graeffe_transform(a, a, prec);
+        if (!acb_poly_equal(a, b))
+        {
+            flint_printf("FAIL (aliasing)\n\n");
+            flint_printf("n = %wd, prec = %wd\n\n", n, prec);
+
+            flint_printf("a: "); acb_poly_printd(a, 15); flint_printf("\n\n");
+            flint_printf("b: "); acb_poly_printd(b, 15); flint_printf("\n\n");
+            flint_printf("c: "); acb_poly_printd(c, 15); flint_printf("\n\n");
+
+            flint_abort();
+        }
+
+        _acb_vec_clear(roots, n);
+    }
+
+    acb_poly_clear(a);
+    acb_poly_clear(b);
+    acb_poly_clear(c);
+
+    flint_randclear(state);
+    flint_cleanup();
+    flint_printf("PASS\n");
+    return EXIT_SUCCESS;
+}
+

--- a/arb_poly.h
+++ b/arb_poly.h
@@ -512,6 +512,10 @@ void _arb_poly_binomial_transform(arb_ptr b, arb_srcptr a, slong alen, slong len
 
 void arb_poly_binomial_transform(arb_poly_t b, const arb_poly_t a, slong len, slong prec);
 
+void _arb_poly_graeffe_transform(arb_ptr b, arb_srcptr a, slong len, slong prec);
+
+void arb_poly_graeffe_transform(arb_poly_t b, const arb_poly_t a, slong prec);
+
 /* Special functions */
 
 void _arb_poly_pow_ui_trunc_binexp(arb_ptr res,

--- a/arb_poly/graeffe_transform.c
+++ b/arb_poly/graeffe_transform.c
@@ -14,14 +14,21 @@
 void
 _arb_poly_graeffe_transform(arb_ptr b, arb_srcptr a, slong len, slong prec)
 {
-    if (len == 0)
+    slong lo, le, ls;
+    slong i;
+    arb_ptr pe, po;
+
+    if (len <= 1)
+    {
+        _arb_vec_set(b, a, len);
         return;
+    }
 
-    slong q, i;
-
-    q = (len - 1) / 2 + 1;
-    arb_ptr pe = _arb_vec_init(q);
-    arb_ptr po = _arb_vec_init(len);
+    lo = len / 2;
+    ls = 2 * lo - 1;
+    le = (len - 1) / 2 + 1;
+    po = _arb_vec_init(lo);
+    pe = _arb_vec_init(FLINT_MAX(le, ls));
 
     for (i = len - 1; i >= 0; i--)
     {
@@ -31,16 +38,18 @@ _arb_poly_graeffe_transform(arb_ptr b, arb_srcptr a, slong len, slong prec)
             arb_set(po + i / 2, a + i);
     }
 
-    _arb_poly_mul(b, po, q, po, q, prec);
-    _arb_poly_shift_left(b, b, len - 1, 1);
-    _arb_poly_mul(po, pe, q, pe, q, prec);
-    _arb_vec_sub(b, po, b, len, prec);
-
-    _arb_vec_clear(pe, q);
-    _arb_vec_clear(po, len);
+    _arb_poly_mul(b, pe, le, pe, le, prec);
+    _arb_poly_mul(pe, po, lo, po, lo, prec);
+    _arb_poly_sub(b + 1, b + 1, ls, pe, ls, prec);
 
     if (len % 2 == 0)
-	    _arb_vec_neg(b, b, len);
+    {
+        _arb_vec_neg(b, b, len - 1);
+        arb_set(b + (len - 1), pe + (len - 2));
+    }
+
+    _arb_vec_clear(pe, FLINT_MAX(le, ls));
+    _arb_vec_clear(po, lo);
 }
 
 void

--- a/arb_poly/graeffe_transform.c
+++ b/arb_poly/graeffe_transform.c
@@ -19,20 +19,20 @@ _arb_poly_graeffe_transform(arb_ptr b, arb_srcptr a, slong len, slong prec)
 
     slong q, i;
 
-    q = (len-1)/2+1;
+    q = (len - 1) / 2 + 1;
     arb_ptr pe = _arb_vec_init(q);
     arb_ptr po = _arb_vec_init(len);
 
-    for (i = len-1; i >= 0; i--)
+    for (i = len - 1; i >= 0; i--)
     {
         if (i % 2 == 0)
-            arb_set(pe+i/2, a+i);
+            arb_set(pe + i / 2, a + i);
         else
-            arb_set(po+i/2, a+i);
+            arb_set(po + i / 2, a + i);
     }
 
     _arb_poly_mul(b, po, q, po, q, prec);
-    _arb_poly_shift_left(b, b, len-1, 1);
+    _arb_poly_shift_left(b, b, len - 1, 1);
     _arb_poly_mul(po, pe, q, pe, q, prec);
     _arb_vec_sub(b, po, b, len, prec);
 

--- a/arb_poly/graeffe_transform.c
+++ b/arb_poly/graeffe_transform.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2012 Fredrik Johansson
+    Copyright (C) 2021 Matthias Gessinger
 
     This file is part of Arb.
 

--- a/arb_poly/graeffe_transform.c
+++ b/arb_poly/graeffe_transform.c
@@ -1,0 +1,52 @@
+/*
+    Copyright (C) 2012 Fredrik Johansson
+
+    This file is part of Arb.
+
+    Arb is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "arb_poly.h"
+
+void
+_arb_poly_graeffe_transform(arb_ptr b, arb_srcptr a, slong len, slong prec)
+{
+    if (len == 0)
+        return;
+
+    slong q, i;
+
+    q = (len-1)/2+1;
+    arb_ptr pe = _arb_vec_init(q);
+    arb_ptr po = _arb_vec_init(len);
+
+    for (i = len-1; i >= 0; i--)
+    {
+        if (i % 2 == 0)
+            arb_set(pe+i/2, a+i);
+        else
+            arb_set(po+i/2, a+i);
+    }
+
+    _arb_poly_mul(b, po, q, po, q, prec);
+    _arb_poly_shift_left(b, b, len-1, 1);
+    _arb_poly_mul(po, pe, q, pe, q, prec);
+    _arb_vec_sub(b, po, b, len, prec);
+
+    _arb_vec_clear(pe, q);
+    _arb_vec_clear(po, len);
+
+    if (len % 2 == 0)
+	    _arb_vec_neg(b, b, len);
+}
+
+void
+arb_poly_graeffe_transform(arb_poly_t b, const arb_poly_t a, slong prec)
+{
+    arb_poly_fit_length(b, a->length);
+    _arb_poly_graeffe_transform(b->coeffs, a->coeffs, a->length, prec);
+    _arb_poly_set_length(b, a->length);
+}

--- a/arb_poly/graeffe_transform.c
+++ b/arb_poly/graeffe_transform.c
@@ -14,8 +14,7 @@
 void
 _arb_poly_graeffe_transform(arb_ptr b, arb_srcptr a, slong len, slong prec)
 {
-    slong lo, le, ls;
-    slong i;
+    slong lo, le, ls, deg, i;
     arb_ptr pe, po;
 
     if (len <= 1)
@@ -24,13 +23,14 @@ _arb_poly_graeffe_transform(arb_ptr b, arb_srcptr a, slong len, slong prec)
         return;
     }
 
+    deg = len - 1;
     lo = len / 2;
     ls = 2 * lo - 1;
-    le = (len - 1) / 2 + 1;
+    le = deg / 2 + 1;
     po = _arb_vec_init(lo);
     pe = _arb_vec_init(FLINT_MAX(le, ls));
 
-    for (i = len - 1; i >= 0; i--)
+    for (i = deg; i >= 0; i--)
     {
         if (i % 2 == 0)
             arb_set(pe + i / 2, a + i);
@@ -44,8 +44,8 @@ _arb_poly_graeffe_transform(arb_ptr b, arb_srcptr a, slong len, slong prec)
 
     if (len % 2 == 0)
     {
-        _arb_vec_neg(b, b, len - 1);
-        arb_set(b + (len - 1), pe + (len - 2));
+        _arb_vec_neg(b, b, deg);
+        arb_set(b + deg, pe + (deg - 1));
     }
 
     _arb_vec_clear(pe, FLINT_MAX(le, ls));

--- a/arb_poly/test/t-graeffe_transform.c
+++ b/arb_poly/test/t-graeffe_transform.c
@@ -1,0 +1,86 @@
+/*
+    Copyright (C) 2013 Fredrik Johansson
+
+    This file is part of Arb.
+
+    Arb is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "arb_poly.h"
+
+int main()
+{
+    slong iter;
+    flint_rand_t state;
+
+    flint_printf("graeffe_transform....");
+    fflush(stdout);
+
+    flint_randinit(state);
+
+    arb_poly_t a, b, c;
+    arb_poly_init(a);
+    arb_poly_init(b);
+    arb_poly_init(c);
+
+    arb_ptr roots;
+
+    for (iter = 0; iter < 500 * arb_test_multiplier(); iter++)
+    {
+        slong n, prec, i;
+        n = n_randint(state, 200);
+        prec = 2 + n_randint(state, 200);
+
+        roots = _arb_vec_init(n);
+        for (i = 0; i < n; i++)
+                arb_randtest(roots+i, state, prec, n_randint(state, 10));
+
+        arb_poly_product_roots(a, roots, n, prec);
+
+        for (i = 0; i < n; i++)
+                arb_sqr(roots+i, roots+i, prec);
+
+        arb_poly_product_roots(c, roots, n, prec);
+
+        arb_poly_graeffe_transform(b, a, prec);
+        if (!arb_poly_overlaps(b, c))
+        {
+            flint_printf("FAIL (containment)\n\n");
+            flint_printf("n = %wd, prec = %wd\n\n", n, prec);
+
+            flint_printf("a: "); arb_poly_printd(a, 15); flint_printf("\n\n");
+            flint_printf("b: "); arb_poly_printd(b, 15); flint_printf("\n\n");
+            flint_printf("c: "); arb_poly_printd(c, 15); flint_printf("\n\n");
+
+            flint_abort();
+        }
+
+        arb_poly_graeffe_transform(a, a, prec);
+        if (!arb_poly_equal(a, b))
+        {
+            flint_printf("FAIL (aliasing)\n\n");
+            flint_printf("n = %wd, prec = %wd\n\n", n, prec);
+
+            flint_printf("a: "); arb_poly_printd(a, 15); flint_printf("\n\n");
+            flint_printf("b: "); arb_poly_printd(b, 15); flint_printf("\n\n");
+            flint_printf("c: "); arb_poly_printd(c, 15); flint_printf("\n\n");
+
+            flint_abort();
+        }
+
+        _arb_vec_clear(roots, n);
+    }
+
+    arb_poly_clear(a);
+    arb_poly_clear(b);
+    arb_poly_clear(c);
+
+    flint_randclear(state);
+    flint_cleanup();
+    flint_printf("PASS\n");
+    return EXIT_SUCCESS;
+}
+

--- a/arb_poly/test/t-graeffe_transform.c
+++ b/arb_poly/test/t-graeffe_transform.c
@@ -15,13 +15,13 @@ int main()
 {
     slong iter;
     flint_rand_t state;
+    arb_poly_t a, b, c;
 
     flint_printf("graeffe_transform....");
     fflush(stdout);
 
     flint_randinit(state);
 
-    arb_poly_t a, b, c;
     arb_poly_init(a);
     arb_poly_init(b);
     arb_poly_init(c);
@@ -31,6 +31,7 @@ int main()
     for (iter = 0; iter < 200 * arb_test_multiplier(); iter++)
     {
         slong n, prec, i;
+
         n = n_randint(state, 20);
         prec = 2 + n_randint(state, 256);
 
@@ -47,7 +48,7 @@ int main()
         arb_poly_graeffe_transform(b, a, prec);
         if (!arb_poly_overlaps(b, c))
         {
-            flint_printf("FAIL (containment)\n\n");
+            flint_printf("FAIL (overlap)\n\n");
             flint_printf("n = %wd, prec = %wd\n\n", n, prec);
 
             flint_printf("a: "); arb_poly_printd(a, 15); flint_printf("\n\n");

--- a/arb_poly/test/t-graeffe_transform.c
+++ b/arb_poly/test/t-graeffe_transform.c
@@ -28,21 +28,20 @@ int main()
 
     arb_ptr roots;
 
-    for (iter = 0; iter < 500 * arb_test_multiplier(); iter++)
+    for (iter = 0; iter < 200 * arb_test_multiplier(); iter++)
     {
         slong n, prec, i;
-        n = n_randint(state, 200);
-        prec = 2 + n_randint(state, 200);
+        n = n_randint(state, 20);
+        prec = 2 + n_randint(state, 256);
 
         roots = _arb_vec_init(n);
-        for (i = 0; i < n; i++)
-                arb_randtest(roots+i, state, prec, n_randint(state, 10));
 
+        for (i = 0; i < n; i++)
+                arb_randtest(roots + i, state, prec, n_randint(state, 16));
         arb_poly_product_roots(a, roots, n, prec);
 
         for (i = 0; i < n; i++)
-                arb_sqr(roots+i, roots+i, prec);
-
+                arb_sqr(roots + i, roots + i, prec);
         arb_poly_product_roots(c, roots, n, prec);
 
         arb_poly_graeffe_transform(b, a, prec);

--- a/doc/source/acb_poly.rst
+++ b/doc/source/acb_poly.rst
@@ -656,6 +656,16 @@ Transforms
     The underscore methods do not support aliasing, and assume that
     the lengths are nonzero.
 
+.. function:: void _acb_poly_graeffe_transform(acb_ptr b, acb_srcptr a, slong len, slong prec)
+
+.. function:: void acb_poly_graeffe_transform(acb_poly_t b, acb_poly_t a, slong prec)
+
+    Computes the Graeffe transform of input polynomial, which is of length *len*.
+    See :func:`arb_poly_graeffe_transform` for details.
+
+    The underscore method assumes that *a* and *b* are initialized,
+    *a* is of length *len*, and *b* is of length at least *len*.
+    Both methods allow aliasing.
 
 Elementary functions
 -------------------------------------------------------------------------------

--- a/doc/source/arb_poly.rst
+++ b/doc/source/arb_poly.rst
@@ -722,6 +722,22 @@ Transforms
     The underscore methods do not support aliasing, and assume that
     the lengths are nonzero.
 
+.. function:: void _arb_poly_graeffe_transform(arb_ptr b, arb_srcptr a, slong len, slong prec)
+
+.. function:: void arb_poly_graeffe_transform(arb_poly_t b, arb_poly_t a, slong prec)
+
+    Computes the Graeffe transform of input polynomial.
+
+    The Graeffe transform `G` of a polynomial `P` is defined through the
+    equation `G(x^2) = \pm P(x)P(-x)`.
+    The sign is given by `(-1)^d`, where `d = deg(P)`.
+    The Graeffe transform has the property that its roots are exactly the
+    squares of the roots of P.
+
+    The underscore method assumes that *a* and *b* are initialized,
+    *a* is of length *len*, and *b* is of length at least *len*.
+    Both methods allow aliasing.
+
 Powers and elementary functions
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
If `P` is a polynomial (over an arbitrary ring R), then its Graeffe transform `G` is defined through the equation `G(x^2) = P(x)P(-x)` (up to an overall sign, which is determined by the degree of P).
If L//R is the splitting field of P, then it is easy to see, that G also decomposes over L, and its roots are exactly the squares of the roots of P. In particular, in some cases the roots of G might be real even though those of P were not.
Due to the symmetry of G, we see that in computing `P(x)P(-x)`, half the terms will vanish (namely precisely the odd terms). This wastes time and memory. Instead, this implementation uses the definition in [\[Diouf, Sec. 1.2\]](https://tel.archives-ouvertes.fr/tel-00151313/document), which yields a significant performance benefit for the reason mentioned above.

This polynomial transform finds application in [Graeffe's Method \[Diouf, Sec. 3\]](https://tel.archives-ouvertes.fr/tel-00151313/document) for bounding polynomial roots (or Fujiwara's bound, as is already implemented in `acb_poly_root_bound_fujiwara`).
For the application of said method, the Graeffe Transform will generally be applied many times in a row. As such, it might be of interest to provide another method that takes (alongside the usual arguments) an additional `iterations` parameter, and performs the transform that many times, as opposed to calling the usual function over and over again. The benefit of having such an additional function is to avoid excessive internal memory (de-)allocations.

Tests have been provided for `arb_poly_graeffe_transform` and `acb_poly_graeffe_transform`, using the file `t-acb_poly_borel_transform.c` as style reference. Since the code is identical for the real and complex transform, the tests are also identical. Sadly, the transform doesn't decompose into real and imaginary parts, so code duplication cannot be avoided.