### PR TITLE
Fix Graeffe transform for constant polynomials

### DIFF
--- a/acb_poly/graeffe_transform.c
+++ b/acb_poly/graeffe_transform.c
@@ -19,7 +19,8 @@ _acb_poly_graeffe_transform(acb_ptr b, acb_srcptr a, slong len, slong prec)
 
     if (len <= 1)
     {
-        _acb_vec_set(b, a, len);
+        if (len)
+            acb_sqr(b, a, prec);
         return;
     }
 

--- a/acb_poly/test/t-graeffe_transform.c
+++ b/acb_poly/test/t-graeffe_transform.c
@@ -17,6 +17,7 @@ int main()
     flint_rand_t state;
     acb_poly_t a, b, c;
     acb_ptr roots;
+    acb_t leading;
 
     flint_printf("graeffe_transform....");
     fflush(stdout);
@@ -27,6 +28,8 @@ int main()
     acb_poly_init(b);
     acb_poly_init(c);
 
+    acb_init(leading);
+
     for (iter = 0; iter < 200 * arb_test_multiplier(); iter++)
     {
         slong n, prec, i;
@@ -36,13 +39,18 @@ int main()
 
         roots = _acb_vec_init(n);
 
-        for (i = 0; i < n; i++)
-                acb_randtest(roots + i, state, prec, n_randint(state, 16));
-        acb_poly_product_roots(a, roots, n, prec);
+        acb_randtest(leading, state, prec, n_randint(state, 16));
 
         for (i = 0; i < n; i++)
-                acb_sqr(roots + i, roots + i, prec);
+            acb_randtest(roots + i, state, prec, n_randint(state, 16));
+        acb_poly_product_roots(a, roots, n, prec);
+        acb_poly_scalar_mul(a, a, leading, prec);
+
+        for (i = 0; i < n; i++)
+            acb_sqr(roots + i, roots + i, prec);
+        acb_sqr(leading, leading, prec);
         acb_poly_product_roots(c, roots, n, prec);
+        acb_poly_scalar_mul(c, c, leading, prec);
 
         acb_poly_graeffe_transform(b, a, prec);
         if (!acb_poly_overlaps(b, c))
@@ -76,6 +84,8 @@ int main()
     acb_poly_clear(a);
     acb_poly_clear(b);
     acb_poly_clear(c);
+
+    acb_clear(leading);
 
     flint_randclear(state);
     flint_cleanup();

--- a/arb_poly/graeffe_transform.c
+++ b/arb_poly/graeffe_transform.c
@@ -19,7 +19,8 @@ _arb_poly_graeffe_transform(arb_ptr b, arb_srcptr a, slong len, slong prec)
 
     if (len <= 1)
     {
-        _arb_vec_set(b, a, len);
+        if (len)
+            arb_sqr(b, a, prec);
         return;
     }
 

--- a/arb_poly/test/t-graeffe_transform.c
+++ b/arb_poly/test/t-graeffe_transform.c
@@ -17,6 +17,7 @@ int main()
     flint_rand_t state;
     arb_poly_t a, b, c;
     arb_ptr roots;
+    arb_t leading;
 
     flint_printf("graeffe_transform....");
     fflush(stdout);
@@ -27,6 +28,8 @@ int main()
     arb_poly_init(b);
     arb_poly_init(c);
 
+    arb_init(leading);
+
     for (iter = 0; iter < 200 * arb_test_multiplier(); iter++)
     {
         slong n, prec, i;
@@ -36,13 +39,18 @@ int main()
 
         roots = _arb_vec_init(n);
 
-        for (i = 0; i < n; i++)
-                arb_randtest(roots + i, state, prec, n_randint(state, 16));
-        arb_poly_product_roots(a, roots, n, prec);
+        arb_randtest(leading, state, prec, n_randint(state, 16));
 
         for (i = 0; i < n; i++)
-                arb_sqr(roots + i, roots + i, prec);
+            arb_randtest(roots + i, state, prec, n_randint(state, 16));
+        arb_poly_product_roots(a, roots, n, prec);
+        arb_poly_scalar_mul(a, a, leading, prec);
+
+        for (i = 0; i < n; i++)
+            arb_sqr(roots + i, roots + i, prec);
+        arb_sqr(leading, leading, prec);
         arb_poly_product_roots(c, roots, n, prec);
+        arb_poly_scalar_mul(c, c, leading, prec);
 
         arb_poly_graeffe_transform(b, a, prec);
         if (!arb_poly_overlaps(b, c))
@@ -76,6 +84,8 @@ int main()
     arb_poly_clear(a);
     arb_poly_clear(b);
     arb_poly_clear(c);
+
+    arb_clear(leading);
 
     flint_randclear(state);
     flint_cleanup();


### PR DESCRIPTION
In the case of a constant polynomial (meaning degree 0 or length 1), the Graeffe Transform as implemented in #374 simply returned the input polynomial. That is incorrect; it should return the input polynomial squared.
This PR fixes that, and adapts the test code to cover non-monic polynomials.