### PR TITLE
fix compilation with musl libc

### DIFF
--- a/acb_poly/powsum_series_naive_threaded.c
+++ b/acb_poly/powsum_series_naive_threaded.c
@@ -9,8 +9,8 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
-#include <pthread.h>
 #include "acb_poly.h"
+#include <pthread.h>
 
 typedef struct
 {

--- a/partitions/fmpz_fmpz.c
+++ b/partitions/fmpz_fmpz.c
@@ -9,8 +9,8 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
-#include <pthread.h>
 #include "partitions.h"
+#include <pthread.h>
 
 /* defined in flint*/
 #define NUMBER_OF_SMALL_PARTITIONS 128


### PR DESCRIPTION
In order to use cpu_set_t it is necessary to `#define _GNU_SOURCE` before including `sched.h` (in flint).

However, in musl libc `sched.h` will be included from `pthread.h`. This means by the time flint headers get to include `sched.h`, it has already been included from `pthread.h` so it won't work.

The fix is easy: include flint headers before `#include <pthread.h>`. This is what this PR does.

This together with wbhart/flint2#988 fixes the issue.

I take the oportunity to also note: a different workaround would be to use `-D_GNU_SOURCE` as a compile option.  This actually causes a different issue: it turns out defining `_GNU_SOURCE` before including `math.h` makes the latter define a function `fdiv()` which then causes a conflict with a static function used in `acb_elliptic/rj.c`. It might be wise to choose a different name for that function.
```
rj.c:50:25: error: conflicting types for 'fdiv'
   50 | static __inline__ slong fdiv(slong x, slong y)
      |                         ^~~~
In file included from /home/tornaria/src/flint/arb/arf.h:25,
                 from /home/tornaria/src/flint/arb/acb.h:22,
                 from /home/tornaria/src/flint/arb/acb_elliptic.h:16,
                 from rj.c:12:
/usr/include/bits/mathcalls-narrow.h:27:20: note: previous declaration of 'fdiv' was here
   27 | __MATHCALL_NARROW (__MATHCALL_NAME (div), __MATHCALL_REDIR_NAME (div), 2);
      |                    ^~~~~~~~~~~~~~~
```