### PR TITLE
Add acb_add_error_arb

### DIFF
--- a/acb.h
+++ b/acb.h
@@ -331,6 +331,13 @@ acb_add_error_mag(acb_t x, const mag_t err)
     arb_add_error_mag(acb_imagref(x), err);
 }
 
+ACB_INLINE void
+acb_add_error_arb(acb_t x, const arb_t err)
+{
+    arb_add_error(acb_realref(x), err);
+    arb_add_error(acb_imagref(x), err);
+}
+
 void acb_get_mag(mag_t z, const acb_t x);
 
 void acb_get_mag_lower(mag_t z, const acb_t x);

--- a/doc/source/acb.rst
+++ b/doc/source/acb.rst
@@ -139,7 +139,11 @@ Basic manipulation
 
     Swaps *z* and *x* efficiently.
 
+.. function:: void acb_add_error_arf(acb_t x, const arf_t err)
+
 .. function:: void acb_add_error_mag(acb_t x, const mag_t err)
+
+.. function:: void acb_add_error_arb(acb_t x, const arb_t err)
 
     Adds *err* to the error bounds of both the real and imaginary
     parts of *x*, modifying *x* in-place.


### PR DESCRIPTION
Also add acb_add_error_arf to the documentation.

This is nice to have when developing libraries where error-bounds need to be calculated using arbs (for example if they involve special functions like upper incomplete gamma functions etc.).

Let me know if anything can be improved, or if tests are needed.