### PR TITLE
Correct typos in documentation.

### DIFF
--- a/doc/source/acb_dirichlet.rst
+++ b/doc/source/acb_dirichlet.rst
@@ -193,7 +193,7 @@ the evaluation.
 .. function:: void acb_dirichlet_zeta_jet_rs(acb_t res, const acb_t s, slong len, slong prec)
 
     Computes the first *len* terms of the Taylor series of the Riemann zeta
-    function at *s* using the Riemann siegel formula. This function currently
+    function at *s* using the Riemann Siegel formula. This function currently
     only supports *len* = 1 or *len* = 2. A finite difference is used
     to compute the first derivative.
 
@@ -247,7 +247,7 @@ Hurwitz zeta function precomputation
 
     Clears the precomputed data.
 
-.. function:: void acb_dirichler_hurwitz_precomp_choose_param(ulong * A, ulong * K, ulong * N, const acb_t s, double num_eval, slong prec)
+.. function:: void acb_dirichlet_hurwitz_precomp_choose_param(ulong * A, ulong * K, ulong * N, const acb_t s, double num_eval, slong prec)
 
     Chooses precomputation parameters *A*, *K* and *N* to minimize
     the cost of *num_eval* evaluations of the Hurwitz zeta function
@@ -799,7 +799,7 @@ and formulas described by David J. Platt in [Pla2017]_.
     The number of obtained consecutive zeros is returned. The first two
     function variants each make a single call to Platt's grid evaluation
     of the scaled Lambda function, whereas the third variant performs as many
-    evluations as necessary to obtain *len* consecutive zeros.
+    evaluations as necessary to obtain *len* consecutive zeros.
     The final several parameters of the underscored local variant have the same
     meanings as in the functions :func:`acb_dirichlet_platt_multieval`
     and :func:`acb_dirichlet_platt_ws_interpolation`. The non-underscored

--- a/doc/source/acb_poly.rst
+++ b/doc/source/acb_poly.rst
@@ -677,7 +677,7 @@ Elementary functions
     of the power as computed without truncation (i.e. no zero-padding is performed).
     Does not support aliasing of the input and output, and requires
     that *flen* and *len* are positive.
-    Uses binary expontiation.
+    Uses binary exponentiation.
 
 .. function:: void acb_poly_pow_ui_trunc_binexp(acb_poly_t res, const acb_poly_t poly, ulong exp, slong len, slong prec)
 

--- a/doc/source/arb_poly.rst
+++ b/doc/source/arb_poly.rst
@@ -748,7 +748,7 @@ Powers and elementary functions
     of the power as computed without truncation (i.e. no zero-padding is performed).
     Does not support aliasing of the input and output, and requires
     that *flen* and *len* are positive.
-    Uses binary expontiation.
+    Uses binary exponentiation.
 
 .. function:: void arb_poly_pow_ui_trunc_binexp(arb_poly_t res, const arb_poly_t poly, ulong exp, slong len, slong prec)
 

--- a/doc/source/bool_mat.rst
+++ b/doc/source/bool_mat.rst
@@ -254,7 +254,7 @@ Special functions
     that of :func:`nilpotency_degree`.
 
     This function can help quantify entrywise errors in a truncated evaluation
-    of a matrix power series.  If *A* is an indictor matrix with the same
+    of a matrix power series.  If *A* is an indicator matrix with the same
     sparsity pattern as a matrix `M` over the real or complex numbers,
     and if `B_{ij}` does not take the special value `-2`, then the tail
     `\left[ \sum_{k=N}^\infty a_k M^k \right]_{ij}`


### PR DESCRIPTION
I noticed that the function `acb_dirichler_hurwitz_precomp_choose_param`
had misspelled `dirichlet` in the documentation (not the code). This
corrects that, and a few other less important typos at the same time.