### PR TITLE
Fixing MINGW64 build

### DIFF
--- a/configure
+++ b/configure
@@ -317,11 +317,23 @@ KERNEL=`uname`
 if [ -z "$BUILD" ]; then
    ARCH=`uname -m`
 
-   if [ "$(uname | cut -d_ -f1)" = "MINGW32" ]; then
+   if [ "$(uname | cut -d_ -f1)" = "MSYS" ]; then
+      if [ "$ARCH" = "x86_64" ]; then
+         OS="MINGW64"
+      else
+         OS="MINGW32"
+      fi
+   elif [ "$(uname | cut -d_ -f1)" = "MINGW32" ]; then
       if [ "$ABI" = "64" ]; then
          OS="MINGW64"
       else
          OS="MINGW32"
+      fi 
+   elif [ "$(uname | cut -d_ -f1)" = "MINGW64" ]; then
+      if [ "$ABI" = "32" ]; then
+         OS="MINGW32"
+      else
+         OS="MINGW64"
       fi
    elif [ "$(uname | cut -d_ -f1)" = "CYGWIN" ]; then
       if [ "$ARCH" = "x86_64" ]; then
@@ -508,7 +520,7 @@ fi
 
 if [ -z "$CFLAGS" ]; then
    if [ "$OS" = "MINGW64" ]; then
-      CFLAGS="-O2 -funroll-loops -g $POPCNT_FLAG $ABI_FLAG"
+      CFLAGS="-std=c99 -O2 -funroll-loops -g $POPCNT_FLAG $ABI_FLAG"
    elif [ "$OS" = "CYGWIN64" ]; then
       CFLAGS="-O2 -funroll-loops -g -D _WIN64 $POPCNT_FLAG $ABI_FLAG"
    else


### PR DESCRIPTION
ARB does not build correctly in `MINGW64`. `-std=c99` needs to be added to `CFLAGS` in `configure` script. Also copied some more logic related to auto detection of `OS` and `ARCH` from https://github.com/fredrik-johansson/flint2/blob/trunk/configure 