### PR TITLE
Fix arb_pow for x just barely containing 0, y>0.

### DIFF
--- a/arb/pow.c
+++ b/arb/pow.c
@@ -13,28 +13,36 @@
 
 #define BINEXP_LIMIT 64
 
+typedef enum {POSITIVE = 0, NEGATIVE_EVEN, NEGATIVE_ODD} sign_type;
+
 void
-_arb_pow_exp(arb_t z, const arb_t x, int negx, const arb_t y, slong prec)
+_arb_pow_exp(arb_t z, const arb_t x, sign_type negx, const arb_t y, slong prec)
 {
     arb_t t;
     arb_init(t);
 
-    if (negx)
+    if (negx == POSITIVE)
+        arb_log(t, x, prec);
+    else
     {
         arb_neg(t, x);
         arb_log(t, t, prec);
     }
-    else
-        arb_log(t, x, prec);
 
     arb_mul(t, t, y, prec);
     arb_exp(z, t, prec);
+
+    if (negx == NEGATIVE_ODD)
+        arb_neg(z, z);
+
     arb_clear(t);
 }
 
 void
 arb_pow(arb_t z, const arb_t x, const arb_t y, slong prec)
 {
+    sign_type s;
+
     if (arb_is_zero(y))
     {
         arb_one(z);
@@ -49,6 +57,9 @@ arb_pow(arb_t z, const arb_t x, const arb_t y, slong prec)
             arb_indeterminate(z);
         return;
     }
+
+
+    s = POSITIVE;
 
     if (arb_is_exact(y) && !arf_is_special(arb_midref(x)))
     {
@@ -86,17 +97,48 @@ arb_pow(arb_t z, const arb_t x, const arb_t y, slong prec)
             return;
         }
         else if (arf_is_int(ymid) && arf_sgn(arb_midref(x)) < 0)
-        {
             /* use (-x)^n = (-1)^n * x^n to avoid NaNs
                at least at high enough precision */
-            int odd = !arf_is_int_2exp_si(ymid, 1);
-            _arb_pow_exp(z, x, 1, y, prec);
-            if (odd)
-                arb_neg(z, z);
-            return;
-        }
+            s = arf_is_int_2exp_si(ymid, 1) ? NEGATIVE_EVEN : NEGATIVE_ODD;
+        /* Fallthrough */
     }
 
-    _arb_pow_exp(z, x, 0, y, prec);
+    if (arf_cmp_si(arb_midref(x), 0) > 0
+        && arf_cmpabs_mag(arb_midref(x), arb_radref(x)) == 0
+        && arb_is_nonnegative(y)) {
+        /* x is an interval of the form <a +- a>, y is an interval of the form
+           <b +- c> with b >= c.
+
+           (x, y) -> x^y is nondecreasing in x for y >= 0, and it is 0 for x=0
+           and y>0.  The lower bound of the interval for x is 0, and we have
+           points with y>0 (because the case arb_is_zero(y) is excluded
+           above). So the lowerbound of the result is 0, and the upperbound can
+           be found somewhere at (2*a)^y.
+
+           We compute this upperbound by computing z^y with z = <3*a/2 +- a/2>,
+           which has the same upperbound (2*a) as x, then keeping the upper
+           bound of this result and setting the lower bound to 0. This
+           necessarily drops the precision to MAG_BITS, so we might as well do
+           that from the start. */
+        prec = (prec > MAG_BITS) ? MAG_BITS : prec;
+        arf_mul_ui(arb_midref(z), arb_midref(x), 3, prec, ARF_RND_UP);
+        arf_mul_2exp_si(arb_midref(z), arb_midref(z), -1);
+        mag_mul_2exp_si(arb_radref(z), arb_radref(x), -1);
+
+        arb_pow(z, z, y, prec);
+
+        /* Now we keep the upper bound of z (we may need to round up) and set the lower bound to
+           zero. That is, if currently, z = <zc +/- zr>, we set it to <(zc + zr)/2 +/- (zc +
+           zr)/2>. */
+        arb_get_ubound_arf(arb_midref(z), z, prec);
+        arf_mul_2exp_si(arb_midref(z), arb_midref(z), -1);
+        arf_get_mag(arb_radref(z), arb_midref(z));
+        /* Note the above is inexact (rounding up), so need to update arb_midref(z) to match again */
+        arf_set_mag(arb_midref(z), arb_radref(z));
+
+        return;
+    }
+    
+    _arb_pow_exp(z, x, s, y, prec);
 }
 

--- a/arb/test/t-pow.c
+++ b/arb/test/t-pow.c
@@ -10,6 +10,7 @@
 */
 
 #include "arb.h"
+#include "flint/double_extras.h"
 
 int main()
 {
@@ -107,6 +108,78 @@ int main()
         arb_clear(d);
         arb_clear(e);
         arb_clear(f);
+    }
+
+    for (iter = 0; iter < 1000 * arb_test_multiplier(); iter++)
+    {
+        ulong n, prec;
+        double epsilon, delta;
+        arb_t a, b, c, d;
+
+        arb_init(a);
+        arb_init(b);
+        arb_init(c);
+        arb_init(d);
+
+        prec = 2 + n_randint(state, 100);
+
+        mag_randtest(arb_radref(a), state, 1 + n_randint(state, 1000));
+        arf_set_mag(arb_midref(a), arb_radref(a));
+
+        n = 1 + n_randint(state, 100);
+        epsilon = d_randtest(state) / 16; /* 1/32 <= epsilon < 1/16 */
+        if (n_randint(state, 2))
+            epsilon = -epsilon;
+        delta = d_randtest(state) / 4; /* 1/8 <= delta < 1/4 */
+        arf_set_d(arb_midref(b), n + epsilon);
+        mag_set_d(arb_radref(b), delta);
+
+        arb_pow(c, a, b, prec);
+        arb_pow_ui(d, a, n, prec);
+
+        if (!arb_overlaps(c, d))
+        {
+            flint_printf("FAIL: interval from zero\n\n");
+            flint_printf("a = "); arb_print(a); flint_printf("\n\n");
+            flint_printf("n = %d\n\n", n);
+            flint_printf("b = "); arb_print(b); flint_printf("\n\n");
+            flint_printf("c = "); arb_print(c); flint_printf("\n\n");
+            flint_printf("d = "); arb_print(d); flint_printf("\n\n");
+            flint_abort();
+        }
+
+        arb_set(c, a);
+        arb_pow(c, c, b, prec);
+
+        if (!arb_overlaps(c, d))
+        {
+            flint_printf("FAIL: interval from zero; alias 1\n\n");
+            flint_printf("a = "); arb_print(a); flint_printf("\n\n");
+            flint_printf("n = %d\n\n", n);
+            flint_printf("b = "); arb_print(b); flint_printf("\n\n");
+            flint_printf("c = "); arb_print(c); flint_printf("\n\n");
+            flint_printf("d = "); arb_print(d); flint_printf("\n\n");
+            flint_abort();
+        }
+
+        arb_set(c, b);
+        arb_pow(c, a, c, prec);
+        
+        if (!arb_overlaps(c, d))
+        {
+            flint_printf("FAIL: interval from zero; alias 2\n\n");
+            flint_printf("a = "); arb_print(a); flint_printf("\n\n");
+            flint_printf("n = %d\n\n", n);
+            flint_printf("b = "); arb_print(b); flint_printf("\n\n");
+            flint_printf("c = "); arb_print(c); flint_printf("\n\n");
+            flint_printf("d = "); arb_print(d); flint_printf("\n\n");
+            flint_abort();
+        }
+
+        arb_clear(d);
+        arb_clear(c);
+        arb_clear(b);
+        arb_clear(a);
     }
 
     flint_randclear(state);

--- a/doc/source/arb.rst
+++ b/doc/source/arb.rst
@@ -1029,7 +1029,8 @@ Powers and roots
 
     Sets `z = x^y`, computed using binary exponentiation if `y` is
     a small exact integer, as `z = (x^{1/2})^{2y}` if `y` is a small exact
-    half-integer, and generally as `z = \exp(y \log x)`.
+    half-integer, and generally as `z = \exp(y \log x)`, except giving the
+    obvious finite result if `x` is `a \pm a` and `y` is positive.
 
 Exponentials and logarithms
 -------------------------------------------------------------------------------


### PR DESCRIPTION
I rearranged the existing code for negative exact large integers y a little; explanation follows. Of course I'm happy to undo this if you prefer.

This code interacts with the new branch in a slightly complicated way: if `y` is an exact *small* integer (or half integer), we want to keep using the existing code that calls `arb_pow_fmpz_binexp`, so the new code needs to come *after* that test. However, if `y` is an exact *big* negative integer, then the current code negates `x` if its midpoint is negative, which would screw up the new code if we inserted it after the block testing for `arb_is_exact(y) && !arf_is_special(arb_midref(x))`, keeping the latter unchanged. I assume we want to keep testing that condition only once (as in the original code), so instead of immediately negating `x` and calling `_arb_pow_exp`, I chose to instead just *store* the decision that `x` needs to be negated. Furthermore, in the original code, `_arb_pow_exp` takes a flag for negating the input, but the calling code has to negate the result if applicable; given that the decision now needs to be stored, I thought it a little cleaner to store both decisions in one variable and do both steps in `_arb_pow_exp`. That's what the `sign_type` is about.

The most obvious alternative would be to store the result of the test `arb_is_exact(y) && !arf_is_special(arb_midref(x))` and mirror the original code a bit more closely, inserting the new code truly in between the two parts of the big `if` block. I'd be entirely happy to do it that way instead if you prefer.